### PR TITLE
Update base paths for root deployment

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -9,9 +9,9 @@
     // Redirect to the base URL with hash routing
     const path = window.location.pathname.slice(1);
     if (path) {
-      window.location.replace(`${window.location.origin}/fishing-report/#/${path}`);
+      window.location.replace(`${window.location.origin}/#/${path}`);
     } else {
-      window.location.replace(`${window.location.origin}/fishing-report/`);
+      window.location.replace(`${window.location.origin}/`);
     }
   </script>
 </head>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,7 +9,7 @@
       "type": "image/svg+xml"
     }
   ],
-  "start_url": "/fishing-report/",
+  "start_url": "/",
   "display": "standalone",
   "theme_color": "#2563eb",
   "background_color": "#ffffff"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,24 +1,24 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/fishing-report/',
+  base: "/",
   build: {
-    outDir: 'dist',
+    outDir: "dist",
     sourcemap: true,
     rollupOptions: {
       output: {
         manualChunks: {
-          vendor: ['react', 'react-dom', 'react-router-dom'],
-        }
-      }
-    }
+          vendor: ["react", "react-dom", "react-router-dom"],
+        },
+      },
+    },
   },
   test: {
     globals: true,
-    environment: 'jsdom',
-    setupFiles: './tests/setup.ts',
-  }
-})
+    environment: "jsdom",
+    setupFiles: "./tests/setup.ts",
+  },
+});


### PR DESCRIPTION
Adjust base paths in `404.html`, `manifest.json`, and `vite.config.ts` to support deployment at the root level instead of a subdirectory.