### PR TITLE
Set VITE_BASE_PATH for GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -50,6 +50,8 @@ jobs:
         
       - name: Build application
         run: npm run build
+        env:
+          VITE_BASE_PATH: /fishing-report/
         
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,8 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: "/",
+  // Use repo root when deployed to GitHub Pages, else default to root for local dev
+  base: process.env.VITE_BASE_PATH || "/",
   build: {
     outDir: "dist",
     sourcemap: true,


### PR DESCRIPTION
Configure the application to use a base path specific to GitHub Pages, allowing for proper routing when deployed. This change ensures that the application can function correctly both in local development and when hosted on GitHub Pages.