### PR TITLE
Weather accuracy

### DIFF
--- a/AGENTS_CHANGELOG.md
+++ b/AGENTS_CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 ## 2026-07-03
 

--- a/AGENTS_CHANGELOG.md
+++ b/AGENTS_CHANGELOG.md
@@ -1,4 +1,19 @@
-# Changelog
+﻿# Changelog
+
+## 2026-07-03
+
+### Weather Trust and Accuracy Overhaul
+
+- **Removed** all synthetic/default weather fallbacks (20C / 10 km/h / 50% clouds / 1013.25 hPa) from `enhancedWeather.ts` and `openMeteo.ts`; weather fetchers now throw or report UNAVAILABLE instead of fabricating data
+- **Changed** `fetchEnhancedWeather` to return a discriminated result (`OK` / `FALLBACK` / `UNAVAILABLE`); total source failure blocks the bite score
+- **Added** `buildUnavailableForecast` in `forecast.ts` producing a blocked forecast (safety UNKNOWN, score suppressed) and a degraded ScoreCard state ("Forecast unavailable / Check official weather before fishing")
+- **Fixed** NWS precipitation semantics: grid `probabilityOfPrecipitation` is now `precipProbabilityPct` (0-100), never converted to or displayed as a rain amount; `precipMm` is optional and NWS leaves it unset
+- **Fixed** NWS unit conversions with uom-aware converters (`windSpeed` km/h no longer multiplied by 3.6; pressure Pa->hPa; temperature degF->degC) and Open-Meteo wind requested explicitly in km/h
+- **Changed** reliability timestamps to use source-reported update times (NWS grid `updateTime`); freshness is UNKNOWN when the source provides none, and `forecastGeneratedIso` is tracked separately
+- **Renamed** user-facing "Confidence" to "Data Quality" in ScoreCard and Home copy; internal `confidenceLevel`/`confidenceScore` field names retained
+- **Added** result-card trust summary (outlook + safety, best solunar window, why, data quality) above metrics; unavailable-days banner on Results page
+- **Changed** safety score penalty (DANGEROUS -> 0) to apply regardless of weather source
+- **Added** validation harness: `npm run validate:weather` (25-location deterministic report) and `tests/weatherValidation.test.ts` covering source selection, fallback, blocking, unit conversion, precipitation semantics, safety overrides, and data-quality rules
 
 ## 2025-11-19 v1.3.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,13 +98,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -123,21 +123,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -164,14 +164,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -194,14 +194,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -298,9 +298,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -322,29 +322,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -367,9 +367,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -427,9 +427,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -437,9 +437,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -447,9 +447,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -472,27 +472,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1069,16 +1069,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+      "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.29.0"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1656,33 +1656,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1690,14 +1690,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2683,9 +2683,9 @@
       "license": "MIT"
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -2698,10 +2698,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-babel": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.1.0.tgz",
+      "integrity": "sha512-dFZNuFD2YRcoomP4oYf+DvQNSUA9ih+A3vUqopQx5EdtPGo3WBnQcI/S8pwpz91UsGfL0HsMSOlaMld8HrbubA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.18.6",
+        "@rollup/pluginutils": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@types/babel__core": "^7.1.9",
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/babel__core": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
-      "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2723,19 +2750,41 @@
         }
       }
     },
-    "node_modules/@rollup/plugin-terser": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
-      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "serialize-javascript": "^6.0.1",
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+      "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "serialize-javascript": "^7.0.3",
         "smob": "^1.0.0",
         "terser": "^5.17.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "rollup": "^2.0.0||^3.0.0||^4.0.0"
@@ -2747,9 +2796,9 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
-      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3126,29 +3175,6 @@
         "win32"
       ]
     },
-    "node_modules/@surma/rollup-plugin-off-main-thread": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
-      "integrity": "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ejs": "^3.1.6",
-        "json5": "^2.2.0",
-        "magic-string": "^0.25.0",
-        "string.prototype.matchall": "^4.0.6"
-      }
-    },
-    "node_modules/@surma/rollup-plugin-off-main-thread/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
     "node_modules/@testing-library/dom": {
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
@@ -3223,6 +3249,22 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
+      "version": "3.0.0-pre1",
+      "resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
+      "integrity": "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ejs": "^3.1.10",
+        "json5": "^2.2.3",
+        "magic-string": "^0.30.21",
+        "string.prototype.matchall": "^4.0.12"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@types/aria-query": {
@@ -3616,9 +3658,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
-      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.6.tgz",
+      "integrity": "sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3640,8 +3682,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.2.4",
-        "vitest": "3.2.4"
+        "@vitest/browser": "3.2.6",
+        "vitest": "3.2.6"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -3650,15 +3692,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -3667,13 +3709,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -3694,9 +3736,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3707,13 +3749,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.6",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -3722,13 +3764,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -3737,9 +3779,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3750,13 +3792,13 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.4.tgz",
-      "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.6.tgz",
+      "integrity": "sha512-mATfG3zVdhobE9U1rIpvtYD3DGuSSxqZ3Aj/8ityGqKXy8YDJ9BoAjZmAz6dZ1IZ1xI5V+MerkCczvVa+3QK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.6",
         "fflate": "^0.8.2",
         "flatted": "^3.3.3",
         "pathe": "^2.0.3",
@@ -3768,17 +3810,17 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "3.2.4"
+        "vitest": "3.2.6"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -4083,9 +4125,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4147,15 +4189,15 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -4262,9 +4304,9 @@
       }
     },
     "node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4688,9 +4730,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4756,6 +4798,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -4805,9 +4866,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4834,15 +4895,18 @@
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
         "is-callable": "^1.2.7",
-        "is-date-object": "^1.0.5",
-        "is-symbol": "^1.0.4"
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5146,6 +5210,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eta": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-4.6.0.tgz",
+      "integrity": "sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/bgub/eta?sponsor=1"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
@@ -5178,9 +5255,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "dev": true,
       "funding": [
         {
@@ -5256,9 +5333,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5296,17 +5373,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -5364,18 +5441,21 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
-        "hasown": "^2.0.2",
-        "is-callable": "^1.2.7"
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5714,9 +5794,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6017,6 +6097,22 @@
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6438,10 +6534,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6627,13 +6733,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -6827,9 +6926,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -7097,9 +7196,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7120,9 +7219,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -7140,7 +7239,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7229,16 +7328,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -7282,12 +7371,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -7297,13 +7386,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -7540,15 +7629,15 @@
       "license": "MIT"
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
@@ -7558,27 +7647,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -7658,13 +7726,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {
@@ -7851,9 +7919,9 @@
       }
     },
     "node_modules/smob": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.1.tgz",
-      "integrity": "sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.2.tgz",
+      "integrity": "sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7933,14 +8001,6 @@
         "tr46": "^1.0.1",
         "webidl-conversions": "^4.0.2"
       }
-    },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -8069,19 +8129,20 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8091,16 +8152,16 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
+        "es-object-atoms": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8577,18 +8638,18 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0",
-        "reflect.getprototypeof": "^1.0.6"
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8774,13 +8835,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.2.tgz",
-      "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -8902,6 +8963,490 @@
         }
       }
     },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -8921,20 +9466,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -8964,8 +9509,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -9186,30 +9731,30 @@
       }
     },
     "node_modules/workbox-background-sync": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.0.tgz",
-      "integrity": "sha512-8CB9OxKAgKZKyNMwfGZ1XESx89GryWTfI+V5yEj8sHjFH8MFelUwYXEyldEK6M6oKMmn807GoJFUEA1sC4XS9w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.1.tgz",
+      "integrity": "sha512-HhT7KE8tOWDm02wRNshXUnUPofMlhenF2DBdUnDPOubhizzPeItkYTmAB6td1Z2cjYPa98vzEiPLEuzn5hN66g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "idb": "^7.0.1",
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-broadcast-update": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.4.0.tgz",
-      "integrity": "sha512-+eZQwoktlvo62cI0b+QBr40v5XjighxPq3Fzo9AWMiAosmpG5gxRHgTbGGhaJv/q/MFVxwFNGh/UwHZ/8K88lA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.4.1.tgz",
+      "integrity": "sha512-uAlgslKLvbQY+suirIdnBCSYrcgBhjp81Nj4l1lj/Jmj0MJO2CJERnCJjT0GFVwmReV0N+zs78K6gqd5gr9/+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-build": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.4.0.tgz",
-      "integrity": "sha512-Ntk1pWb0caOFIvwz/hfgrov/OJ45wPEhI5PbTywQcYjyZiVhT3UrwwUPl6TRYbTm4moaFYithYnl1lvZ8UjxcA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.4.1.tgz",
+      "integrity": "sha512-SDhxIvEAde9Gy/5w4Yo1Jh/M49Z0qE3q0oteyE8zGq0DScxFqVBcCtIXFuLtmtxRQZCMbf0prco4VyEu3KBQuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9217,39 +9762,39 @@
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.11.0",
         "@babel/runtime": "^7.11.2",
-        "@rollup/plugin-babel": "^5.2.0",
-        "@rollup/plugin-node-resolve": "^15.2.3",
-        "@rollup/plugin-replace": "^2.4.1",
-        "@rollup/plugin-terser": "^0.4.3",
-        "@surma/rollup-plugin-off-main-thread": "^2.2.3",
+        "@rollup/plugin-babel": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "@rollup/plugin-replace": "^6.0.3",
+        "@rollup/plugin-terser": "^1.0.0",
+        "@trickfilm400/rollup-plugin-off-main-thread": "^3.0.0-pre1",
         "ajv": "^8.6.0",
         "common-tags": "^1.8.0",
+        "eta": "^4.5.1",
         "fast-json-stable-stringify": "^2.1.0",
         "fs-extra": "^9.0.1",
         "glob": "^11.0.1",
-        "lodash": "^4.17.20",
         "pretty-bytes": "^5.3.0",
-        "rollup": "^2.79.2",
+        "rollup": "^4.53.3",
         "source-map": "^0.8.0-beta.0",
         "stringify-object": "^3.3.0",
         "strip-comments": "^2.0.1",
         "tempy": "^0.6.0",
         "upath": "^1.2.0",
-        "workbox-background-sync": "7.4.0",
-        "workbox-broadcast-update": "7.4.0",
-        "workbox-cacheable-response": "7.4.0",
-        "workbox-core": "7.4.0",
-        "workbox-expiration": "7.4.0",
-        "workbox-google-analytics": "7.4.0",
-        "workbox-navigation-preload": "7.4.0",
-        "workbox-precaching": "7.4.0",
-        "workbox-range-requests": "7.4.0",
-        "workbox-recipes": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0",
-        "workbox-streams": "7.4.0",
-        "workbox-sw": "7.4.0",
-        "workbox-window": "7.4.0"
+        "workbox-background-sync": "7.4.1",
+        "workbox-broadcast-update": "7.4.1",
+        "workbox-cacheable-response": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-expiration": "7.4.1",
+        "workbox-google-analytics": "7.4.1",
+        "workbox-navigation-preload": "7.4.1",
+        "workbox-precaching": "7.4.1",
+        "workbox-range-requests": "7.4.1",
+        "workbox-recipes": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1",
+        "workbox-streams": "7.4.1",
+        "workbox-sw": "7.4.1",
+        "workbox-window": "7.4.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -9273,69 +9818,6 @@
         "ajv": ">=8"
       }
     },
-    "node_modules/workbox-build/node_modules/@rollup/plugin-babel": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
-      "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@rollup/pluginutils": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "@types/babel__core": "^7.1.9",
-        "rollup": "^1.20.0||^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/babel__core": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/workbox-build/node_modules/@rollup/plugin-replace": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz",
-      "integrity": "sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "magic-string": "^0.25.7"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0"
-      }
-    },
-    "node_modules/workbox-build/node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
-    "node_modules/workbox-build/node_modules/@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/workbox-build/node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -9353,42 +9835,12 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/workbox-build/node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/workbox-build/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/workbox-build/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
-    "node_modules/workbox-build/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/workbox-build/node_modules/pretty-bytes": {
       "version": "5.6.0",
@@ -9403,157 +9855,141 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/workbox-build/node_modules/rollup": {
-      "version": "2.80.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
-      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/workbox-cacheable-response": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.4.0.tgz",
-      "integrity": "sha512-0Fb8795zg/x23ISFkAc7lbWes6vbw34DGFIMw31cwuHPgDEC/5EYm6m/ZkylLX0EnEbbOyOCLjKgFS/Z5g0HeQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.4.1.tgz",
+      "integrity": "sha512-8xaFoJdDc2OjrlbbL3gEeBO1WKcMwRqwLRupgqahYXu75yXajPLuwrbXMrIGZuWYXrQwk0xDjOxZ/ujCy/oJYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-core": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.0.tgz",
-      "integrity": "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.1.tgz",
+      "integrity": "sha512-DT+vu46eh/2vRsSHTY4Xmc32Z1rr9PRlQUXr1Dx30ZuXRWwOsvZgGgcwxcasubQLQmbTNYZjv44LkBAQ4tT5tQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/workbox-expiration": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.4.0.tgz",
-      "integrity": "sha512-V50p4BxYhtA80eOvulu8xVfPBgZbkxJ1Jr8UUn0rvqjGhLDqKNtfrDfjJKnLz2U8fO2xGQJTx/SKXNTzHOjnHw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.4.1.tgz",
+      "integrity": "sha512-lRKUF7b+OGbeXkQk1s6MHXOa3d7Xxf7Of31W6c6hCfipfIyrtdWZ89stq21AHZMaoG7VNFoHply4Ox+rU31TWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "idb": "^7.0.1",
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-google-analytics": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.4.0.tgz",
-      "integrity": "sha512-MVPXQslRF6YHkzGoFw1A4GIB8GrKym/A5+jYDUSL+AeJw4ytQGrozYdiZqUW1TPQHW8isBCBtyFJergUXyNoWQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.4.1.tgz",
+      "integrity": "sha512-Mks1JwLEt++ZAkF6sS1OpSh9RtAMIsiDgRpK+codiHGIPXeaUOgi4cPc3GFadUl8V5QPeypEk8Oxgl3HlwVzHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-background-sync": "7.4.0",
-        "workbox-core": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0"
+        "workbox-background-sync": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
       }
     },
     "node_modules/workbox-navigation-preload": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.4.0.tgz",
-      "integrity": "sha512-etzftSgdQfjMcfPgbfaZCfM2QuR1P+4o8uCA2s4rf3chtKTq/Om7g/qvEOcZkG6v7JZOSOxVYQiOu6PbAZgU6w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.4.1.tgz",
+      "integrity": "sha512-C4KVsjPcYKJOhr631AxR9XoG2rLF3QiTk5aMv36MXOjtWvm8axwNFAtKUPGsWUwLXXAMgYM1En7fsvndaXeXRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-precaching": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.4.0.tgz",
-      "integrity": "sha512-VQs37T6jDqf1rTxUJZXRl3yjZMf5JX/vDPhmx2CPgDDKXATzEoqyRqhYnRoxl6Kr0rqaQlp32i9rtG5zTzIlNg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.4.1.tgz",
+      "integrity": "sha512-cdr/9qByww7yzEp7zg/qI4ukUrrNjQLgN+ONQRpjy/VqGQXwkgHwr00KksGJK8v0VifwDXBb8a4cWNZH71jn3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0"
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
       }
     },
     "node_modules/workbox-range-requests": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.4.0.tgz",
-      "integrity": "sha512-3Vq854ZNuP6Y0KZOQWLaLC9FfM7ZaE+iuQl4VhADXybwzr4z/sMmnLgTeUZLq5PaDlcJBxYXQ3U91V7dwAIfvw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.4.1.tgz",
+      "integrity": "sha512-7i2oxAUE82gHdAJBCAQ04JzNOdRPqzuOzGfoUyJpFSmeqBNYGPrAH8GPoPjUQTfp+NycwrD2H68VtuF8qxv0vQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-recipes": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.4.0.tgz",
-      "integrity": "sha512-kOkWvsAn4H8GvAkwfJTbwINdv4voFoiE9hbezgB1sb/0NLyTG4rE7l6LvS8lLk5QIRIto+DjXLuAuG3Vmt3cxQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.4.1.tgz",
+      "integrity": "sha512-gnbVfmV4/TtmQaM4x9AtuXhcdstJsep3XMVeztOrQVPT+R6+6DeBjGTCQ7fFCXm+4GEHUA5VEBTyi5+4gWGeog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-cacheable-response": "7.4.0",
-        "workbox-core": "7.4.0",
-        "workbox-expiration": "7.4.0",
-        "workbox-precaching": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0"
+        "workbox-cacheable-response": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-expiration": "7.4.1",
+        "workbox-precaching": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
       }
     },
     "node_modules/workbox-routing": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.4.0.tgz",
-      "integrity": "sha512-C/ooj5uBWYAhAqwmU8HYQJdOjjDKBp9MzTQ+otpMmd+q0eF59K+NuXUek34wbL0RFrIXe/KKT+tUWcZcBqxbHQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.4.1.tgz",
+      "integrity": "sha512-yubJGErZOusuidAenaL5ypfhQOa7urxP/f8E0ws7FPb4039RiWXUWBAyUkmUoOL/BcQGen3h0J8872d51IYxtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-strategies": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.4.0.tgz",
-      "integrity": "sha512-T4hVqIi5A4mHi92+5EppMX3cLaVywDp8nsyUgJhOZxcfSV/eQofcOA6/EMo5rnTNmNTpw0rUgjAI6LaVullPpg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.4.1.tgz",
+      "integrity": "sha512-GZxpaw9NbmOelj7667uZ2kpk5BFpOGbO4X0qjwh5ls8XQ8C+Lha5LQchTiUzsTFSS+NlUpftYAyOVXvQUrcqOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-streams": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.4.0.tgz",
-      "integrity": "sha512-QHPBQrey7hQbnTs5GrEVoWz7RhHJXnPT+12qqWM378orDMo5VMJLCkCM1cnCk+8Eq92lccx/VgRZ7WAzZWbSLg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.4.1.tgz",
+      "integrity": "sha512-HWWtraKUbJknd9kgqGcpQ3G114HOPYvqs8HaJMDs2ebLNAimDkVDaWfAXE6Ybl+m8U6KsCE6pWyLYuigWmnAXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0",
-        "workbox-routing": "7.4.0"
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1"
       }
     },
     "node_modules/workbox-sw": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.4.0.tgz",
-      "integrity": "sha512-ltU+Kr3qWR6BtbdlMnCjobZKzeV1hN+S6UvDywBrwM19TTyqA03X66dzw1tEIdJvQ4lYKkBFox6IAEhoSEZ8Xw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.4.1.tgz",
+      "integrity": "sha512-fez5f2DUlDJWTFYkCWQpY10N8gtztd849NswCbVFk0QlcSM4HT5A8x4g4ii650yem4I8tHY0R7JZahwp3ltIPw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/workbox-window": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.0.tgz",
-      "integrity": "sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.1.tgz",
+      "integrity": "sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/trusted-types": "^2.0.2",
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/wrap-ansi": {
@@ -9658,9 +10094,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fishing-report",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fishing-report",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fishing-report",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Production-ready React + TypeScript fishing forecast app",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "build:data": "tsx scripts/build-data.ts",
     "diagnose:noaa": "tsx scripts/noaa-diagnostics.ts",
+    "validate:weather": "tsx scripts/validate-weather.ts",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/scripts/validate-weather.ts
+++ b/scripts/validate-weather.ts
@@ -50,7 +50,7 @@ const LOCATIONS: LocationCase[] = [
   { name: "Corpus Christi, TX", lat: 27.7793, lon: -97.5114, expectUS: true, expectMarineEligible: true },
   { name: "Seattle, WA", lat: 47.6062, lon: -122.3321, expectUS: true, expectMarineEligible: true },
   { name: "San Diego, CA", lat: 32.7157, lon: -117.1611, expectUS: true, expectMarineEligible: true },
-  { name: "Honolulu, HI", lat: 21.3045, lon: -157.8557, expectUS: false, expectMarineEligible: true },
+  { name: "Honolulu, HI", lat: 21.3045, lon: -157.8557, expectUS: true, expectMarineEligible: true },
   { name: "Anchorage, AK", lat: 61.2181, lon: -149.9003, expectUS: true, expectMarineEligible: false },
   { name: "Oklahoma City, OK", lat: 35.4676, lon: -97.5164, expectUS: true, expectMarineEligible: false },
   { name: "Salt Lake City, UT", lat: 40.7608, lon: -111.891, expectUS: true, expectMarineEligible: false },
@@ -61,8 +61,10 @@ const LOCATIONS: LocationCase[] = [
   { name: "Boise, ID", lat: 43.615, lon: -116.2023, expectUS: true, expectMarineEligible: true },
   { name: "Kansas City, MO", lat: 39.0997, lon: -94.5786, expectUS: true, expectMarineEligible: false },
   { name: "Atlanta, GA", lat: 33.749, lon: -84.388, expectUS: true, expectMarineEligible: true },
+  // Toronto sits south of Detroit's latitude, inside the Great Lakes
+  // peninsula a bounding box can't carve out; documents the known limitation.
   { name: "Toronto, ON", lat: 43.6532, lon: -79.3832, expectUS: true, expectMarineEligible: true },
-  { name: "Vancouver, BC", lat: 49.2827, lon: -123.1207, expectUS: true, expectMarineEligible: false },
+  { name: "Vancouver, BC", lat: 49.2827, lon: -123.1207, expectUS: false, expectMarineEligible: false },
   { name: "Mexico City, MX", lat: 19.4326, lon: -99.1332, expectUS: false, expectMarineEligible: false },
   { name: "Cancun, MX", lat: 21.1619, lon: -86.8515, expectUS: false, expectMarineEligible: false },
   { name: "Paris, FR", lat: 48.8566, lon: 2.3522, expectUS: false, expectMarineEligible: false },
@@ -243,7 +245,7 @@ console.log(`Checks: ${passed}/${total} passed`);
 console.log(`Pass rate: ${passRate}%`);
 console.log(`Blocked unsafe/missing forecasts: ${blockedRate}%`);
 console.log(
-  "Known limitations: precipitation amount unavailable from NWS grid PoP; Open-Meteo provides no source update timestamp (freshness UNKNOWN); US bounds are rough (Hawaii routes to Open-Meteo)"
+  "Known limitations: precipitation amount unavailable from NWS grid PoP; Open-Meteo provides no source update timestamp (freshness UNKNOWN); US bounds are rough rectangles (southern Ontario/Quebec near the Great Lakes still routes to NWS)"
 );
 
 if (failed > 0) {

--- a/scripts/validate-weather.ts
+++ b/scripts/validate-weather.ts
@@ -1,0 +1,255 @@
+/**
+ * Weather data validation harness.
+ *
+ * Deterministic contract checks over the weather pipeline: source selection,
+ * unit conversion, precipitation semantics, safety overrides, and data
+ * quality (reliability) rules. No network calls; safe for CI.
+ *
+ * Run: npm run validate:weather
+ */
+import {
+  adjustSafetyWithMarine,
+  evaluateMarinePrefilter,
+  isUSLocation,
+} from "../src/lib/enhancedWeather";
+import {
+  NWSWeatherService,
+  clampProbabilityPct,
+  convertPressureToHpa,
+  convertTemperatureToC,
+  convertWindToKph,
+} from "../src/lib/nwsWeather";
+import {
+  buildUnavailableForecast,
+  scorePrecipitation,
+  scoreWeather,
+} from "../src/lib/forecast";
+import { buildForecastReliability } from "../src/lib/forecastReliability";
+import type {
+  EnhancedWeatherData,
+  SafetyAssessment,
+} from "../src/types/forecast";
+
+interface LocationCase {
+  name: string;
+  lat: number;
+  lon: number;
+  expectUS: boolean;
+  expectMarineEligible: boolean;
+}
+
+// 25 locations spanning US inland, US coastal, Great Lakes, and international.
+const LOCATIONS: LocationCase[] = [
+  { name: "Denver, CO", lat: 39.7392, lon: -104.9903, expectUS: true, expectMarineEligible: false },
+  { name: "Milton, WI", lat: 42.7756, lon: -88.9443, expectUS: true, expectMarineEligible: true },
+  { name: "Chicago, IL", lat: 41.8781, lon: -87.6298, expectUS: true, expectMarineEligible: true },
+  { name: "Duluth, MN", lat: 46.7867, lon: -92.1005, expectUS: true, expectMarineEligible: true },
+  { name: "New York, NY", lat: 40.7128, lon: -74.006, expectUS: true, expectMarineEligible: true },
+  { name: "Boston, MA", lat: 42.3601, lon: -71.0589, expectUS: true, expectMarineEligible: true },
+  { name: "Miami, FL", lat: 25.7617, lon: -80.1918, expectUS: true, expectMarineEligible: true },
+  { name: "Corpus Christi, TX", lat: 27.7793, lon: -97.5114, expectUS: true, expectMarineEligible: true },
+  { name: "Seattle, WA", lat: 47.6062, lon: -122.3321, expectUS: true, expectMarineEligible: true },
+  { name: "San Diego, CA", lat: 32.7157, lon: -117.1611, expectUS: true, expectMarineEligible: true },
+  { name: "Honolulu, HI", lat: 21.3045, lon: -157.8557, expectUS: false, expectMarineEligible: true },
+  { name: "Anchorage, AK", lat: 61.2181, lon: -149.9003, expectUS: true, expectMarineEligible: false },
+  { name: "Oklahoma City, OK", lat: 35.4676, lon: -97.5164, expectUS: true, expectMarineEligible: false },
+  { name: "Salt Lake City, UT", lat: 40.7608, lon: -111.891, expectUS: true, expectMarineEligible: false },
+  { name: "Nashville, TN", lat: 36.1627, lon: -86.7816, expectUS: true, expectMarineEligible: false },
+  { name: "Phoenix, AZ", lat: 33.4484, lon: -112.074, expectUS: true, expectMarineEligible: false },
+  // Boise and Atlanta sit inside the coarse coastal rectangles used by the
+  // marine prefilter; eligibility here documents current behavior.
+  { name: "Boise, ID", lat: 43.615, lon: -116.2023, expectUS: true, expectMarineEligible: true },
+  { name: "Kansas City, MO", lat: 39.0997, lon: -94.5786, expectUS: true, expectMarineEligible: false },
+  { name: "Atlanta, GA", lat: 33.749, lon: -84.388, expectUS: true, expectMarineEligible: true },
+  { name: "Toronto, ON", lat: 43.6532, lon: -79.3832, expectUS: true, expectMarineEligible: true },
+  { name: "Vancouver, BC", lat: 49.2827, lon: -123.1207, expectUS: true, expectMarineEligible: false },
+  { name: "Mexico City, MX", lat: 19.4326, lon: -99.1332, expectUS: false, expectMarineEligible: false },
+  { name: "Cancun, MX", lat: 21.1619, lon: -86.8515, expectUS: false, expectMarineEligible: false },
+  { name: "Paris, FR", lat: 48.8566, lon: 2.3522, expectUS: false, expectMarineEligible: false },
+  { name: "Tokyo, JP", lat: 35.6762, lon: 139.6503, expectUS: false, expectMarineEligible: false },
+];
+
+let passed = 0;
+let failed = 0;
+const failures: string[] = [];
+
+function check(label: string, condition: boolean) {
+  if (condition) {
+    passed += 1;
+  } else {
+    failed += 1;
+    failures.push(label);
+  }
+}
+
+function closeTo(actual: number, expected: number, tolerance = 0.01): boolean {
+  return Math.abs(actual - expected) <= tolerance;
+}
+
+function makeSafety(): SafetyAssessment {
+  return { rating: "GOOD", activeAlerts: [], recommendations: [], riskFactors: [] };
+}
+
+function makeWeather(): EnhancedWeatherData {
+  return {
+    tempC: 18,
+    windKph: 10,
+    precipMm: 0,
+    cloudPct: 30,
+    safety: makeSafety(),
+    barometricTrend: "STEADY",
+    source: "NWS",
+  };
+}
+
+// --- Source selection (US bounds + marine prefilter) ---
+for (const loc of LOCATIONS) {
+  check(
+    `${loc.name}: US-bounds classification (expected ${loc.expectUS ? "NWS-primary" : "Open-Meteo-primary"})`,
+    isUSLocation(loc.lat, loc.lon) === loc.expectUS
+  );
+  check(
+    `${loc.name}: marine prefilter (expected ${loc.expectMarineEligible ? "eligible" : "not eligible"})`,
+    evaluateMarinePrefilter(loc.lat, loc.lon).eligible === loc.expectMarineEligible
+  );
+}
+
+// --- Unit correctness ---
+check("wind: km/h uom passes through", closeTo(convertWindToKph(10, "wmoUnit:km_h-1"), 10));
+check("wind: m/s converts to km/h", closeTo(convertWindToKph(10, "wmoUnit:m_s-1"), 36));
+check("wind: knots convert to km/h", closeTo(convertWindToKph(10, "wmoUnit:kn"), 18.52));
+check("pressure: Pa converts to hPa", closeTo(convertPressureToHpa(101325, "wmoUnit:Pa"), 1013.25));
+check("pressure: hPa passes through", closeTo(convertPressureToHpa(1013.25, "wmoUnit:hPa"), 1013.25));
+check("temperature: degC passes through", closeTo(convertTemperatureToC(20, "wmoUnit:degC"), 20));
+check("temperature: degF converts to C", closeTo(convertTemperatureToC(68, "wmoUnit:degF"), 20));
+check("PoP clamps below 0", clampProbabilityPct(-5) === 0);
+check("PoP clamps above 100", clampProbabilityPct(140) === 100);
+
+// --- Precipitation semantics ---
+check("precip: amount scoring takes precedence", scorePrecipitation(12, 90) === 0.1);
+check(
+  "precip: 90% probability is not scored as 0.9mm light rain",
+  scorePrecipitation(undefined, 90) !== scorePrecipitation(0.9, undefined)
+);
+check("precip: high probability scores poorly", scorePrecipitation(undefined, 95) === 0.2);
+check("precip: neither available scores neutral", scorePrecipitation(undefined, undefined) === 0.6);
+
+// --- Cloud cover bounds ---
+for (const cloudPct of [0, 100]) {
+  const score = scoreWeather({ tempC: 18, windKph: 10, precipMm: 0, cloudPct });
+  check(`cloud cover ${cloudPct}%: weather score stays in 0..1`, score >= 0 && score <= 1);
+}
+
+// --- Safety overrides ---
+const service = new NWSWeatherService();
+const calm = { tempC: 20, windKph: 10, precipMm: 0, cloudPct: 50 };
+const alertBase = {
+  id: "v1",
+  headline: "Validation",
+  urgency: "Future" as const,
+  certainty: "Possible" as const,
+  event: "Validation Event",
+  description: "",
+  areas: [],
+};
+
+check(
+  "safety: Severe alert forces DANGEROUS",
+  service.assessSafety([{ ...alertBase, severity: "Severe" }], calm).rating === "DANGEROUS"
+);
+check(
+  "safety: Extreme alert forces DANGEROUS",
+  service.assessSafety([{ ...alertBase, severity: "Extreme" }], calm).rating === "DANGEROUS"
+);
+check(
+  "safety: Moderate alert degrades to FAIR",
+  service.assessSafety([{ ...alertBase, severity: "Moderate" }], calm).rating === "FAIR"
+);
+check(
+  "safety: marine wind >= 55 km/h forces DANGEROUS",
+  adjustSafetyWithMarine(makeSafety(), { windSpeedKph: 60 }, "2026-07-03").rating === "DANGEROUS"
+);
+check(
+  "safety: marine waves >= 3m force DANGEROUS",
+  adjustSafetyWithMarine(makeSafety(), { waveHeight: 3.5 }, "2026-07-03").rating === "DANGEROUS"
+);
+check(
+  "safety: DANGEROUS zeroes the weather score regardless of source",
+  scoreWeather({
+    ...calm,
+    safety: { ...makeSafety(), rating: "DANGEROUS" },
+    barometricTrend: "STEADY",
+    source: "OPEN_METEO",
+  }) === 0
+);
+
+// --- Data quality (reliability) ---
+const unknownFreshness = buildForecastReliability(makeWeather(), {
+  isMarineEligible: false,
+  nowIso: "2026-07-03T12:00:00Z",
+  forecastGeneratedIso: "2026-07-03T12:00:00Z",
+});
+check("quality: missing source timestamp yields UNKNOWN freshness", unknownFreshness.weatherFreshness === "UNKNOWN");
+check("quality: UNKNOWN freshness is penalized", unknownFreshness.confidenceScore < 100);
+
+const primaryQuality = buildForecastReliability(makeWeather(), {
+  isMarineEligible: false,
+  isFallbackSource: false,
+  nowIso: "2026-07-03T12:00:00Z",
+  weatherLastUpdatedIso: "2026-07-03T11:00:00Z",
+});
+const fallbackQuality = buildForecastReliability(
+  { ...makeWeather(), source: "OPEN_METEO" },
+  {
+    isMarineEligible: false,
+    isFallbackSource: true,
+    nowIso: "2026-07-03T12:00:00Z",
+    weatherLastUpdatedIso: "2026-07-03T11:00:00Z",
+  }
+);
+check("quality: fallback source reduces data quality", fallbackQuality.confidenceScore < primaryQuality.confidenceScore);
+
+const missingMarineQuality = buildForecastReliability(makeWeather(), {
+  isMarineEligible: true,
+  nowIso: "2026-07-03T12:00:00Z",
+  weatherLastUpdatedIso: "2026-07-03T11:00:00Z",
+});
+check(
+  "quality: marine-eligible location missing marine data reduces quality",
+  missingMarineQuality.marineStatus === "UNAVAILABLE" &&
+    missingMarineQuality.confidenceScore < primaryQuality.confidenceScore
+);
+
+// --- Blocked forecasts ---
+const blocked = buildUnavailableForecast({ date: "2026-07-03", lat: 39.7, lon: -104.9 }, "validation");
+const blockedChecks =
+  blocked.forecastStatus === "WEATHER_UNAVAILABLE" &&
+  blocked.biteScore0100 === 0 &&
+  blocked.weather.safety.rating === "UNKNOWN" &&
+  Number.isNaN(blocked.weather.tempC);
+check("blocking: total weather failure never yields a normal score", blockedChecks);
+
+// --- Report ---
+const total = passed + failed;
+const passRate = total > 0 ? ((passed / total) * 100).toFixed(1) : "0.0";
+const blockedRate = blockedChecks ? "100" : "0";
+
+console.log("Weather data validation");
+console.log(`Locations tested: ${LOCATIONS.length}`);
+console.log(
+  "Fields tested: temp, wind, precipitation (probability vs amount), cloud cover, pressure, alerts"
+);
+console.log(`Checks: ${passed}/${total} passed`);
+console.log(`Pass rate: ${passRate}%`);
+console.log(`Blocked unsafe/missing forecasts: ${blockedRate}%`);
+console.log(
+  "Known limitations: precipitation amount unavailable from NWS grid PoP; Open-Meteo provides no source update timestamp (freshness UNKNOWN); US bounds are rough (Hawaii routes to Open-Meteo)"
+);
+
+if (failed > 0) {
+  console.error("\nFailed checks:");
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}

--- a/scripts/validate-weather.ts
+++ b/scripts/validate-weather.ts
@@ -234,7 +234,7 @@ check("blocking: total weather failure never yields a normal score", blockedChec
 // --- Report ---
 const total = passed + failed;
 const passRate = total > 0 ? ((passed / total) * 100).toFixed(1) : "0.0";
-const blockedRate = blockedChecks ? "100" : "0";
+const blockedStatus = blockedChecks ? "PASS" : "FAIL";
 
 console.log("Weather data validation");
 console.log(`Locations tested: ${LOCATIONS.length}`);
@@ -243,7 +243,7 @@ console.log(
 );
 console.log(`Checks: ${passed}/${total} passed`);
 console.log(`Pass rate: ${passRate}%`);
-console.log(`Blocked unsafe/missing forecasts: ${blockedRate}%`);
+console.log(`Blocked unsafe/missing forecasts: ${blockedStatus}`);
 console.log(
   "Known limitations: precipitation amount unavailable from NWS grid PoP; Open-Meteo provides no source update timestamp (freshness UNKNOWN); US bounds are rough rectangles (southern Ontario/Quebec near the Great Lakes still routes to NWS)"
 );

--- a/src/components/ScoreCard.test.tsx
+++ b/src/components/ScoreCard.test.tsx
@@ -134,13 +134,15 @@ describe("ScoreCard", () => {
     expect(screen.queryByTestId("weather-alerts")).not.toBeInTheDocument();
   });
 
-  it("renders confidence and recency metadata", () => {
+  it("renders data quality and recency metadata", () => {
     render(<ScoreCard forecast={mockForecastWithMarine} lat={40} lon={-74} />);
 
-    expect(screen.getByText("Confidence: HIGH")).toBeInTheDocument();
-    expect(screen.getByText("Score 92/100")).toBeInTheDocument();
-    expect(screen.getByText(/Weather last updated:/)).toBeInTheDocument();
-    expect(screen.getByText(/Marine last updated:/)).toBeInTheDocument();
+    expect(screen.getByText("Data quality: HIGH")).toBeInTheDocument();
+    expect(screen.getByText("Data quality score 92/100")).toBeInTheDocument();
+    expect(screen.queryByText(/Confidence/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Forecast generated:/)).toBeInTheDocument();
+    expect(screen.getByText(/Weather source updated:/)).toBeInTheDocument();
+    expect(screen.getByText(/Marine observation updated:/)).toBeInTheDocument();
     expect(screen.queryByText(/Marine status: AVAILABLE/)).not.toBeInTheDocument();
     expect(screen.queryByText(/freshness/i)).not.toBeInTheDocument();
   });
@@ -163,9 +165,81 @@ describe("ScoreCard", () => {
     };
 
     render(<ScoreCard forecast={forecast} lat={40} lon={-74} />);
-    expect(screen.getByText("Confidence: MEDIUM")).toBeInTheDocument();
+    expect(screen.getByText("Data quality: MEDIUM")).toBeInTheDocument();
     expect(screen.getByText(/Marine status: UNAVAILABLE/)).toBeInTheDocument();
     expect(screen.queryByText(/freshness/i)).not.toBeInTheDocument();
+  });
+
+  it("shows unknown source freshness instead of claiming fresh data", () => {
+    const forecast = {
+      ...mockForecastWithoutMarine,
+      weather: {
+        ...mockForecastWithoutMarine.weather,
+        reliability: {
+          ...mockForecastWithoutMarine.weather.reliability!,
+          weatherFreshness: "UNKNOWN" as const,
+          weatherLastUpdatedIso: undefined,
+          marineStatus: "NOT_APPLICABLE" as const,
+        },
+      },
+    };
+
+    render(<ScoreCard forecast={forecast} lat={40} lon={-74} />);
+    expect(
+      screen.getByText(/Weather source updated:\s*Unknown/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders a blocked card without a bite score when weather is unavailable", () => {
+    const forecast: ForecastScore = {
+      ...mockForecastWithoutMarine,
+      weather: {
+        ...mockForecastWithoutMarine.weather,
+        tempC: NaN,
+        windKph: NaN,
+        precipMm: undefined,
+        cloudPct: NaN,
+        source: "UNAVAILABLE",
+        safety: {
+          rating: "UNKNOWN",
+          activeAlerts: [],
+          recommendations: [],
+          riskFactors: [],
+        },
+      },
+      biteScore0100: 0,
+      components: {},
+      forecastStatus: "WEATHER_UNAVAILABLE",
+      unavailableReason: "Current weather could not be verified from any source",
+    };
+
+    render(<ScoreCard forecast={forecast} lat={40} lon={-74} />);
+
+    expect(screen.getByTestId("score-card-unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Forecast unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Safety: Unknown")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Check official weather before fishing/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Bite Score")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("score-card")).not.toBeInTheDocument();
+  });
+
+  it("displays precipitation probability separately from amount", () => {
+    const forecast: ForecastScore = {
+      ...mockForecastWithoutMarine,
+      weather: {
+        ...mockForecastWithoutMarine.weather,
+        precipMm: undefined,
+        precipProbabilityPct: 40,
+      },
+    };
+
+    render(<ScoreCard forecast={forecast} lat={40} lon={-74} />);
+
+    expect(screen.getByText("Chance of rain: 40%")).toBeInTheDocument();
+    expect(screen.getByText("Rain amount unavailable")).toBeInTheDocument();
+    expect(screen.queryByText(/Rain amount: /)).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -28,7 +28,12 @@ export default function ScoreCard({
 
   const tempF = Math.round((forecast.weather.tempC * 9) / 5 + 32);
   const windMph = Math.round((forecast.weather.windKph / 1.609) * 10) / 10;
-  const precipIn = Math.round((forecast.weather.precipMm / 25.4) * 100) / 100;
+  const precipMm = forecast.weather.precipMm;
+  const precipIn =
+    precipMm !== undefined
+      ? Math.round((precipMm / 25.4) * 100) / 100
+      : undefined;
+  const precipProbabilityPct = forecast.weather.precipProbabilityPct;
   const pressureInHg = forecast.weather.pressureHpa
     ? Math.round((forecast.weather.pressureHpa * 0.02953) * 100) / 100
     : undefined;
@@ -150,6 +155,118 @@ export default function ScoreCard({
     return `${formatRelativeAge(iso)} @ ${formatIsoForDisplay(iso)}`;
   };
 
+  const getOutlookLabel = (score: number) => {
+    if (score >= 75) return "Good fishing";
+    if (score >= 50) return "Fair fishing";
+    return "Slow fishing";
+  };
+
+  const getSafetyLabel = (rating: SafetyAssessment["rating"]) => {
+    switch (rating) {
+      case "EXCELLENT":
+      case "GOOD":
+        return "Good safety";
+      case "FAIR":
+        return "Fair safety";
+      case "POOR":
+        return "Poor safety";
+      case "DANGEROUS":
+        return "Dangerous conditions";
+      default:
+        return "Safety unknown";
+    }
+  };
+
+  const buildWhySummary = () => {
+    const parts: string[] = [];
+    const wind = forecast.weather.windKph;
+    if (Number.isFinite(wind)) {
+      if (wind <= 18) parts.push("light wind");
+      else if (wind <= 30) parts.push("moderate wind");
+      else parts.push("strong wind");
+    }
+    if (forecast.weather.barometricTrend === "STEADY") {
+      parts.push("stable pressure");
+    } else {
+      parts.push(`${forecast.weather.barometricTrend.toLowerCase()} pressure`);
+    }
+    if (forecast.solunar && forecast.solunar.dayRating >= 2) {
+      parts.push("solunar window");
+    } else {
+      parts.push(`${forecast.moon.phaseName.toLowerCase()}`);
+    }
+    return parts.join(", ");
+  };
+
+  const buildDataQualitySummary = () => {
+    if (!reliability) {
+      return "Unknown";
+    }
+    const sources: string[] = [];
+    if (forecast.weather.source === "NWS") sources.push("NWS");
+    if (forecast.weather.source === "OPEN_METEO") sources.push("Open-Meteo");
+    if (reliability.marineStatus === "AVAILABLE") sources.push("NOAA marine");
+    const sourceText = sources.length > 0 ? ` — ${sources.join(" + ")} checked` : "";
+    return `${reliability.confidenceLevel}${sourceText}`;
+  };
+
+  const bestWindow =
+    forecast.solunar && forecast.solunar.majorPeriods.length > 0
+      ? `${forecast.solunar.majorPeriods[0].start} - ${forecast.solunar.majorPeriods[0].end}`
+      : undefined;
+
+  if (forecast.forecastStatus === "WEATHER_UNAVAILABLE") {
+    return (
+      <div
+        className="card forecast-card"
+        id={cardId}
+        data-testid="score-card-unavailable"
+      >
+        <div className="forecast-card__header" id={`${cardId}-header`}>
+          <div className="forecast-card__title" id={`${cardId}-title`}>
+            <h3 className="text-xl font-semibold forecast-card__heading">
+              {new Date(forecast.date + "T12:00:00").toLocaleDateString(
+                "en-US",
+                {
+                  weekday: "long",
+                  month: "short",
+                  day: "numeric",
+                }
+              )}
+            </h3>
+            <p
+              className="text-sm forecast-card__subtext"
+              id={`${cardId}-local-time`}
+              title={`UTC: ${dateInfo.utc}`}
+            >
+              {dateInfo.local}
+            </p>
+          </div>
+        </div>
+        <div
+          className="forecast-card__section rounded-lg border-2 bg-red-50 border-red-200 p-4"
+          id={`${cardId}-unavailable`}
+        >
+          <div className="flex items-center gap-2 mb-2">
+            <Icon name="warning" className="text-xl" />
+            <h3 className="font-semibold text-lg">Forecast unavailable</h3>
+          </div>
+          <div className="text-sm space-y-1">
+            <p>Safety: Unknown</p>
+            <p>
+              Reason:{" "}
+              {forecast.unavailableReason ||
+                "Current weather could not be verified"}
+            </p>
+            <p className="font-medium">
+              Action: Check official weather before fishing.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="card forecast-card" id={cardId} data-testid="score-card">
       <div className="forecast-card__header" id={`${cardId}-header`}>
@@ -191,13 +308,13 @@ export default function ScoreCard({
                 )}`}
                 id={`${cardId}-confidence-level`}
               >
-                Confidence: {reliability.confidenceLevel}
+                Data quality: {reliability.confidenceLevel}
               </span>
               <span
                 className="text-xs bg-slate-100 text-slate-700 px-2 py-1 rounded"
                 id={`${cardId}-confidence-score`}
               >
-                Score {reliability.confidenceScore}/100
+                Data quality score {reliability.confidenceScore}/100
               </span>
             </div>
           )}
@@ -222,6 +339,20 @@ export default function ScoreCard({
             Bite Score
           </p>
         </div>
+      </div>
+
+      <div
+        className="forecast-card__section forecast-card__summary text-sm space-y-1"
+        id={`${cardId}-summary`}
+        data-testid="score-card-summary"
+      >
+        <p className="font-semibold">
+          {getOutlookLabel(forecast.biteScore0100)},{" "}
+          {getSafetyLabel(safety.rating)}
+        </p>
+        {bestWindow && <p>Best window: {bestWindow}</p>}
+        <p>Why: {buildWhySummary()}</p>
+        <p>Data quality: {buildDataQualitySummary()}</p>
       </div>
 
       <div className="forecast-card__section" id={`${cardId}-score-breakdown`}>
@@ -389,12 +520,16 @@ export default function ScoreCard({
               Wind:{" "}
               {useMph ? `${windMph} mph` : `${forecast.weather.windKph} km/h`}
             </p>
-            <p>
-              Rain:{" "}
-              {useFahrenheit
-                ? `${precipIn} in`
-                : `${forecast.weather.precipMm} mm`}
-            </p>
+            {precipProbabilityPct !== undefined && (
+              <p>Chance of rain: {Math.round(precipProbabilityPct)}%</p>
+            )}
+            {precipMm !== undefined ? (
+              <p>
+                Rain amount: {useFahrenheit ? `${precipIn} in` : `${precipMm} mm`}
+              </p>
+            ) : (
+              <p>Rain amount unavailable</p>
+            )}
             <p>Clouds: {forecast.weather.cloudPct}%</p>
             {forecast.weather.pressureHpa &&
               (useFahrenheit ? (
@@ -556,9 +691,16 @@ export default function ScoreCard({
                 >
                   <p
                     className="forecast-card__reliability-item"
+                    id={`${cardId}-reliability-generated`}
+                  >
+                    Forecast generated:{" "}
+                    {formatLastUpdated(reliability.forecastGeneratedIso)}
+                  </p>
+                  <p
+                    className="forecast-card__reliability-item"
                     id={`${cardId}-reliability-weather`}
                   >
-                    Weather last updated:{" "}
+                    Weather source updated:{" "}
                     {formatLastUpdated(reliability.weatherLastUpdatedIso)}
                   </p>
                   {reliability.marineStatus !== "NOT_APPLICABLE" && (
@@ -567,10 +709,10 @@ export default function ScoreCard({
                       id={`${cardId}-reliability-marine`}
                     >
                       {reliability.marineStatus === "AVAILABLE"
-                        ? `Marine last updated: ${formatLastUpdated(
+                        ? `Marine observation updated: ${formatLastUpdated(
                             reliability.marineLastUpdatedIso
                           )}`
-                        : `Marine status: ${reliability.marineStatus} | Last updated: ${formatLastUpdated(
+                        : `Marine status: ${reliability.marineStatus} | Observation updated: ${formatLastUpdated(
                             reliability.marineLastUpdatedIso
                           )}`}
                     </p>

--- a/src/lib/enhancedWeather.ts
+++ b/src/lib/enhancedWeather.ts
@@ -23,26 +23,40 @@ interface MarinePrefilterResult {
   reason: MarinePrefilterReason;
 }
 
+export type EnhancedWeatherResult =
+  | {
+      status: "OK" | "FALLBACK";
+      weather: EnhancedWeatherData;
+    }
+  | {
+      status: "UNAVAILABLE";
+      reason: string;
+    };
+
+/** Rough US bounds used to decide whether NWS is the primary weather source. */
+export function isUSLocation(lat: number, lon: number): boolean {
+  return lat >= 24.0 && lat <= 71.0 && lon >= -179.0 && lon <= -66.0;
+}
+
 /**
- * Enhanced weather fetcher that prioritizes NWS for US locations
- * and falls back to Open-Meteo for international or on failure
+ * Enhanced weather fetcher that prioritizes NWS for US locations and falls
+ * back to Open-Meteo for international locations or on NWS failure.
+ *
+ * Never fabricates weather: when every source fails, the result is
+ * UNAVAILABLE and the caller must block the bite score.
  */
 export async function fetchEnhancedWeather(
   day: DayInputs
-): Promise<EnhancedWeatherData> {
+): Promise<EnhancedWeatherResult> {
   let weather: EnhancedWeatherData | null = null;
+  let usedFallbackSource = false;
   const marinePrefilter = evaluateMarinePrefilter(day.lat, day.lon);
   const marineEligible = marinePrefilter.eligible;
   const shouldLogMarineDiagnostics = import.meta.env.DEV;
 
-  // Check if location is in the US (rough bounds)
-  const isUSLocation =
-    day.lat >= 24.0 &&
-    day.lat <= 71.0 && // Alaska to Florida
-    day.lon >= -179.0 &&
-    day.lon <= -66.0; // Hawaii to Maine
+  const nwsIsPrimary = isUSLocation(day.lat, day.lon);
 
-  if (isUSLocation) {
+  if (nwsIsPrimary) {
     try {
       // Try NWS first for US locations
       console.log(`Fetching NWS weather data for ${day.lat}, ${day.lon}`);
@@ -58,6 +72,7 @@ export async function fetchEnhancedWeather(
       console.log(`Fetching Open-Meteo weather data for ${day.lat}, ${day.lon}`);
       const openMeteoData = await fetchOpenMeteoWeather(day);
 
+      usedFallbackSource = nwsIsPrimary;
       weather = {
         ...openMeteoData,
         safety: {
@@ -68,24 +83,14 @@ export async function fetchEnhancedWeather(
         },
         barometricTrend: "STEADY",
         source: "OPEN_METEO",
+        // Open-Meteo does not report a model-run timestamp; freshness stays UNKNOWN
+        sourceUpdatedIso: undefined,
       };
     } catch (error) {
       console.error("Both NWS and Open-Meteo failed:", error);
-
-      weather = {
-        tempC: 20.0,
-        windKph: 10.0,
-        precipMm: 0.0,
-        cloudPct: 50,
-        pressureHpa: 1013.25,
-        safety: {
-          rating: "FAIR",
-          activeAlerts: [],
-          recommendations: ["Weather data unavailable - use caution"],
-          riskFactors: ["Unable to fetch current weather conditions"],
-        },
-        barometricTrend: "STEADY",
-        source: "OPEN_METEO",
+      return {
+        status: "UNAVAILABLE",
+        reason: "Current weather could not be verified from any source",
       };
     }
   }
@@ -138,41 +143,23 @@ export async function fetchEnhancedWeather(
     }
   }
 
-  const reliabilityTimestampIso = new Date().toISOString();
+  const forecastGeneratedIso = new Date().toISOString();
 
-  if (!weather) {
-    const fallback: EnhancedWeatherData = {
-      tempC: 20.0,
-      windKph: 10.0,
-      precipMm: 0.0,
-      cloudPct: 50,
-      pressureHpa: 1013.25,
-      safety: {
-        rating: "FAIR",
-        activeAlerts: [],
-        recommendations: ["Weather data unavailable - use caution"],
-        riskFactors: ["Unable to fetch current weather conditions"],
-      },
-      barometricTrend: "STEADY",
-      source: "OPEN_METEO",
-    };
-    return {
-      ...fallback,
-      reliability: buildForecastReliability(fallback, {
-        isMarineEligible: marineEligible,
-        nowIso: reliabilityTimestampIso,
-        weatherLastUpdatedIso: reliabilityTimestampIso,
-      }),
-    };
-  }
-
-  return {
+  const weatherWithReliability: EnhancedWeatherData = {
     ...weather,
     reliability: buildForecastReliability(weather, {
       isMarineEligible: marineEligible,
-      nowIso: reliabilityTimestampIso,
-      weatherLastUpdatedIso: reliabilityTimestampIso,
+      isFallbackSource: usedFallbackSource,
+      nowIso: forecastGeneratedIso,
+      forecastGeneratedIso,
+      // Source-reported timestamp only; never the app fetch time.
+      weatherLastUpdatedIso: weather.sourceUpdatedIso,
     }),
+  };
+
+  return {
+    status: usedFallbackSource ? "FALLBACK" : "OK",
+    weather: weatherWithReliability,
   };
 }
 
@@ -266,7 +253,7 @@ export function getOptimalFishingTimes(weather: EnhancedWeatherData): string[] {
     : ["Standard fishing conditions"];
 }
 
-function adjustSafetyWithMarine(
+export function adjustSafetyWithMarine(
   existingSafety: SafetyAssessment,
   marine: MarineWeatherData,
   isoDate: string

--- a/src/lib/enhancedWeather.ts
+++ b/src/lib/enhancedWeather.ts
@@ -33,9 +33,25 @@ export type EnhancedWeatherResult =
       reason: string;
     };
 
-/** Rough US bounds used to decide whether NWS is the primary weather source. */
+/**
+ * Rough NWS-coverage regions used to decide whether NWS is the primary
+ * weather source. NWS only covers the US; a single lat/lon rectangle spanning
+ * the CONUS lat range also swallows most of Canada, which caused Canadian
+ * locations to be tried against NWS, fail, and get penalized as an
+ * Open-Meteo "fallback" instead of being treated as Open-Meteo-primary.
+ *
+ * These three boxes (CONUS, Alaska, Hawaii) fix that for the common case and
+ * correctly include Hawaii (previously excluded despite being a US state).
+ * The CONUS box still can't cleanly separate the Great Lakes peninsula
+ * (e.g. Toronto sits south of Detroit's latitude), so a thin strip of
+ * southern Ontario/Quebec remains misclassified as NWS-primary. Fixing that
+ * needs a real border polygon, not a bounding box.
+ */
 export function isUSLocation(lat: number, lon: number): boolean {
-  return lat >= 24.0 && lat <= 71.0 && lon >= -179.0 && lon <= -66.0;
+  const conus = lat >= 24.5 && lat <= 49.0 && lon >= -124.8 && lon <= -66.9;
+  const alaska = lat >= 51.0 && lat <= 71.5 && lon >= -179.0 && lon <= -129.0;
+  const hawaii = lat >= 18.5 && lat <= 22.5 && lon >= -160.5 && lon <= -154.5;
+  return conus || alaska || hawaii;
 }
 
 /**

--- a/src/lib/forecast.ts
+++ b/src/lib/forecast.ts
@@ -119,7 +119,8 @@ export function scoreMoon(moonData: MoonData): number {
 export function scoreWeather(
   weatherData: WeatherData | EnhancedWeatherData
 ): number {
-  const { tempC, windKph, precipMm, cloudPct } = weatherData;
+  const { tempC, windKph, precipMm, precipProbabilityPct, cloudPct } =
+    weatherData;
 
   // Wind range 3–18 km/h is optimal
   let windS: number;
@@ -145,17 +146,9 @@ export function scoreWeather(
     cloudS = 0.3 + ((80 - cloudPct) / 40) * 0.7;
   }
 
-  // Light rain OK, heavy rain bad
-  let precipS: number;
-  if (precipMm > 10) {
-    precipS = 0.1;
-  } else if (precipMm < 1) {
-    precipS = 0.8;
-  } else if (precipMm < 5) {
-    precipS = 0.5;
-  } else {
-    precipS = 0.2;
-  }
+  // Light rain OK, heavy rain bad. Amount (mm) and probability (%) are
+  // scored on separate scales — probability is never treated as an amount.
+  const precipS = scorePrecipitation(precipMm, precipProbabilityPct);
 
   // Temp comfort window 10–24°C
   let tempS: number;
@@ -189,8 +182,11 @@ export function scoreWeather(
         enhancementBonus += 0.05; // Ideal wave conditions
       }
     }
+  }
 
-    // Safety penalty
+  // Safety penalty applies regardless of source (marine adjustments can
+  // degrade Open-Meteo-sourced safety too)
+  if ("safety" in weatherData) {
     if (weatherData.safety.rating === "DANGEROUS") {
       return 0.0; // Override everything for safety
     } else if (weatherData.safety.rating === "POOR") {
@@ -205,6 +201,32 @@ export function scoreWeather(
   const finalScore = baseScore + enhancementBonus;
 
   return clamp(0.0, 1.0, finalScore);
+}
+
+/**
+ * Score precipitation 0..1 from amount (preferred) or probability (fallback).
+ * Neutral 0.6 when neither is available so the missing field neither inflates
+ * nor tanks the weather score.
+ */
+export function scorePrecipitation(
+  precipMm: number | undefined,
+  precipProbabilityPct: number | undefined
+): number {
+  if (precipMm !== undefined) {
+    if (precipMm > 10) return 0.1;
+    if (precipMm < 1) return 0.8;
+    if (precipMm < 5) return 0.5;
+    return 0.2;
+  }
+
+  if (precipProbabilityPct !== undefined) {
+    if (precipProbabilityPct < 20) return 0.8;
+    if (precipProbabilityPct < 50) return 0.6;
+    if (precipProbabilityPct < 80) return 0.4;
+    return 0.2;
+  }
+
+  return 0.6;
 }
 
 /**
@@ -298,6 +320,46 @@ export function forecastForDay(
     almanac: almanacData,
     biteScore0100: total,
     components,
+  };
+}
+
+/**
+ * Build a blocked forecast for a day whose weather could not be verified.
+ * The bite score is intentionally 0 with forecastStatus WEATHER_UNAVAILABLE;
+ * the UI must render an unavailable state, never a normal score. Weather
+ * metric fields are NaN so any accidental rendering is visibly broken rather
+ * than plausibly wrong.
+ */
+export function buildUnavailableForecast(
+  day: DayInputs,
+  reason: string
+): ForecastScore {
+  const moonData = getMoonData(day.date);
+
+  return {
+    date: day.date,
+    moon: moonData,
+    weather: {
+      tempC: NaN,
+      windKph: NaN,
+      precipMm: undefined,
+      precipProbabilityPct: undefined,
+      cloudPct: NaN,
+      pressureHpa: undefined,
+      safety: {
+        rating: "UNKNOWN",
+        activeAlerts: [],
+        recommendations: ["Check official weather before fishing"],
+        riskFactors: ["Current weather could not be verified"],
+      },
+      barometricTrend: "STEADY",
+      source: "UNAVAILABLE",
+    },
+    almanac: {},
+    biteScore0100: 0,
+    components: {},
+    forecastStatus: "WEATHER_UNAVAILABLE",
+    unavailableReason: reason,
   };
 }
 

--- a/src/lib/forecastReliability.test.ts
+++ b/src/lib/forecastReliability.test.ts
@@ -41,6 +41,7 @@ describe("buildForecastReliability", () => {
 
     const reliability = buildForecastReliability(weather, {
       isMarineEligible: true,
+      isFallbackSource: true,
       nowIso: "2026-02-25T12:00:00Z",
       weatherLastUpdatedIso: "2026-02-25T10:00:00Z",
     });
@@ -48,6 +49,36 @@ describe("buildForecastReliability", () => {
     expect(reliability.confidenceLevel).toBe("LOW");
     expect(reliability.marineStatus).toBe("UNAVAILABLE");
     expect(reliability.reasons.join(" ")).toContain("fallback");
+  });
+
+  it("does not apply the fallback penalty when Open-Meteo is the primary source", () => {
+    const weather = {
+      ...makeBaseWeather(),
+      source: "OPEN_METEO" as const,
+    };
+
+    const reliability = buildForecastReliability(weather, {
+      isMarineEligible: false,
+      isFallbackSource: false,
+      nowIso: "2026-02-25T12:00:00Z",
+      weatherLastUpdatedIso: "2026-02-25T10:00:00Z",
+    });
+
+    expect(reliability.confidenceLevel).toBe("HIGH");
+    expect(reliability.reasons.join(" ")).not.toContain("fallback");
+  });
+
+  it("carries the forecast-generated timestamp separately from source update time", () => {
+    const weather = makeBaseWeather();
+    const reliability = buildForecastReliability(weather, {
+      isMarineEligible: false,
+      nowIso: "2026-02-25T12:00:00Z",
+      forecastGeneratedIso: "2026-02-25T12:00:00Z",
+      weatherLastUpdatedIso: "2026-02-25T09:00:00Z",
+    });
+
+    expect(reliability.forecastGeneratedIso).toBe("2026-02-25T12:00:00Z");
+    expect(reliability.weatherLastUpdatedIso).toBe("2026-02-25T09:00:00Z");
   });
 
   it("marks stale marine observations and downgrades confidence", () => {

--- a/src/lib/forecastReliability.ts
+++ b/src/lib/forecastReliability.ts
@@ -8,8 +8,17 @@ import type {
 
 interface ReliabilityContext {
   isMarineEligible: boolean;
+  /**
+   * True when the weather came from a fallback source (e.g., Open-Meteo for a
+   * US location after NWS failed). Open-Meteo as the primary source for
+   * non-US locations is not a fallback.
+   */
+  isFallbackSource?: boolean;
   nowIso?: string;
+  /** Source-reported update time. Leave unset (freshness UNKNOWN) when the source provides none. */
   weatherLastUpdatedIso?: string;
+  /** When the app generated the forecast; distinct from source update time. */
+  forecastGeneratedIso?: string;
 }
 
 export function buildForecastReliability(
@@ -24,7 +33,7 @@ export function buildForecastReliability(
   const weatherFreshness = freshnessFromIso(weatherLastUpdatedIso, now);
   score = applyFreshnessPenalty(score, weatherFreshness, "weather", reasons);
 
-  if (weather.source === "OPEN_METEO") {
+  if (context.isFallbackSource) {
     score -= 30;
     reasons.push("Using Open-Meteo fallback instead of NWS primary feed");
   }
@@ -79,6 +88,7 @@ export function buildForecastReliability(
     weatherFreshness,
     marineFreshness,
     marineStatus,
+    forecastGeneratedIso: context.forecastGeneratedIso,
     weatherLastUpdatedIso,
     marineLastUpdatedIso,
   };

--- a/src/lib/nwsWeather.test.ts
+++ b/src/lib/nwsWeather.test.ts
@@ -163,3 +163,50 @@ describe("NWSWeatherService - assessSafety", () => {
     });
   });
 });
+
+describe("NWSWeatherService - calculateBarometricTrend", () => {
+  // Private method; accessed via bracket notation to unit-test the
+  // uom-aware conversion directly rather than through the full fetch path.
+  type BarometricTrendFn = (
+    pressureValues: Array<{ validTime: string; value: number | null }> | undefined,
+    targetDateTime: string,
+    uom?: string
+  ) => "RISING" | "FALLING" | "STEADY";
+  const calculateBarometricTrend = (
+    service as unknown as { calculateBarometricTrend: BarometricTrendFn }
+  ).calculateBarometricTrend.bind(service);
+
+  const targetDateTime = "2026-07-03T12:00:00Z";
+
+  it("classifies RISING from a Pa-scale change (NWS default uom)", () => {
+    const values = [
+      { validTime: "2026-07-03T09:00:00Z", value: 101300 },
+      { validTime: "2026-07-03T15:00:00Z", value: 101500 }, // +200 Pa = +2 hPa
+    ];
+    expect(
+      calculateBarometricTrend(values, targetDateTime, "wmoUnit:Pa")
+    ).toBe("RISING");
+  });
+
+  it("classifies FALLING from an hPa-scale change (previously misread as STEADY)", () => {
+    // A 2 hPa drop reported directly in hPa. Before the uom-aware fix, this
+    // was compared against a >100 threshold meant for Pa and never fired.
+    const values = [
+      { validTime: "2026-07-03T09:00:00Z", value: 1015 },
+      { validTime: "2026-07-03T15:00:00Z", value: 1013 },
+    ];
+    expect(
+      calculateBarometricTrend(values, targetDateTime, "wmoUnit:hPa")
+    ).toBe("FALLING");
+  });
+
+  it("stays STEADY for a sub-threshold hPa-scale change", () => {
+    const values = [
+      { validTime: "2026-07-03T09:00:00Z", value: 1013.2 },
+      { validTime: "2026-07-03T15:00:00Z", value: 1013.6 },
+    ];
+    expect(
+      calculateBarometricTrend(values, targetDateTime, "wmoUnit:hPa")
+    ).toBe("STEADY");
+  });
+});

--- a/src/lib/nwsWeather.ts
+++ b/src/lib/nwsWeather.ts
@@ -25,23 +25,66 @@ interface NWSPointResponse {
   };
 }
 
+interface NWSGridpointQuantity {
+  uom?: string;
+  values: Array<{ validTime: string; value: number | null }>;
+}
+
 interface NWSGridpointResponse {
   properties: {
-    temperature?: { values: Array<{ validTime: string; value: number }> };
-    windSpeed?: { values: Array<{ validTime: string; value: number }> };
-    probabilityOfPrecipitation?: {
-      values: Array<{ validTime: string; value: number }>;
-    };
-    skyCover?: { values: Array<{ validTime: string; value: number }> };
-    pressure?: { values: Array<{ validTime: string; value: number }> };
-    waveHeight?: { values: Array<{ validTime: string; value: number }> };
-    primarySwellDirection?: {
-      values: Array<{ validTime: string; value: number }>;
-    };
-    waterTemperature?: { values: Array<{ validTime: string; value: number }> };
-    visibility?: { values: Array<{ validTime: string; value: number }> };
-    windWaveHeight?: { values: Array<{ validTime: string; value: number }> };
+    updateTime?: string;
+    temperature?: NWSGridpointQuantity;
+    windSpeed?: NWSGridpointQuantity;
+    probabilityOfPrecipitation?: NWSGridpointQuantity;
+    skyCover?: NWSGridpointQuantity;
+    pressure?: NWSGridpointQuantity;
+    waveHeight?: NWSGridpointQuantity;
+    primarySwellDirection?: NWSGridpointQuantity;
+    waterTemperature?: NWSGridpointQuantity;
+    visibility?: NWSGridpointQuantity;
+    windWaveHeight?: NWSGridpointQuantity;
   };
+}
+
+/**
+ * Convert an NWS wind speed value to km/h based on the reported unit.
+ * NWS gridpoints report windSpeed in km/h by default (wmoUnit:km_h-1).
+ */
+export function convertWindToKph(value: number, uom?: string): number {
+  if (uom?.includes("m_s")) {
+    return value * 3.6;
+  }
+  if (uom?.includes("kn")) {
+    return value * 1.852;
+  }
+  if (uom?.includes("mi_h")) {
+    return value * 1.609344;
+  }
+  return value; // km_h-1 or unspecified (NWS default)
+}
+
+/**
+ * Convert an NWS pressure value to hPa based on the reported unit.
+ * NWS gridpoints report pressure in Pa (wmoUnit:Pa) unless stated otherwise.
+ */
+export function convertPressureToHpa(value: number, uom?: string): number {
+  if (uom?.includes("hPa") || uom?.includes("mbar")) {
+    return value;
+  }
+  return value / 100; // Pa -> hPa (NWS default)
+}
+
+/** Convert an NWS temperature value to Celsius based on the reported unit. */
+export function convertTemperatureToC(value: number, uom?: string): number {
+  if (uom?.includes("degF")) {
+    return ((value - 32) * 5) / 9;
+  }
+  return value; // degC or unspecified (NWS default)
+}
+
+/** Clamp a probability-of-precipitation value into 0..100. */
+export function clampProbabilityPct(value: number): number {
+  return Math.max(0, Math.min(100, value));
 }
 
 interface NWSAlertsResponse {
@@ -315,13 +358,15 @@ export class NWSWeatherService {
   }
 
   private extractValueForDate(
-    values: Array<{ validTime: string; value: number }> | undefined,
+    values: Array<{ validTime: string; value: number | null }> | undefined,
     targetDate: string
   ): number | undefined {
     if (!values) return undefined;
 
     const targetDay = targetDate.split("T")[0];
-    const dayValues = values.filter((v) => v.validTime.startsWith(targetDay));
+    const dayValues = values.filter(
+      (v) => v.value !== null && v.validTime.startsWith(targetDay)
+    ) as Array<{ validTime: string; value: number }>;
 
     if (dayValues.length === 0) return undefined;
 
@@ -359,15 +404,15 @@ export class NWSWeatherService {
 
       // Extract weather data for the target date
       const targetDateTime = `${day.date}T12:00:00Z`;
-      const temp = this.extractValueForDate(
+      const tempRaw = this.extractValueForDate(
         gridData.properties.temperature?.values,
         targetDateTime
       );
-      const windSpeed = this.extractValueForDate(
+      const windSpeedRaw = this.extractValueForDate(
         gridData.properties.windSpeed?.values,
         targetDateTime
       );
-      const precipitation = this.extractValueForDate(
+      const precipProbability = this.extractValueForDate(
         gridData.properties.probabilityOfPrecipitation?.values,
         targetDateTime
       );
@@ -375,10 +420,31 @@ export class NWSWeatherService {
         gridData.properties.skyCover?.values,
         targetDateTime
       );
-      const pressure = this.extractValueForDate(
+      const pressureRaw = this.extractValueForDate(
         gridData.properties.pressure?.values,
         targetDateTime
       );
+
+      // Core fields must be real observations/forecasts. Throwing here lets the
+      // caller fall back to Open-Meteo instead of scoring synthetic values.
+      if (tempRaw === undefined || windSpeedRaw === undefined || cloudCover === undefined) {
+        throw new Error(
+          `NWS gridpoint data incomplete for ${day.date} (temp/wind/cloud missing)`
+        );
+      }
+
+      const tempC = convertTemperatureToC(
+        tempRaw,
+        gridData.properties.temperature?.uom
+      );
+      const windKph = convertWindToKph(
+        windSpeedRaw,
+        gridData.properties.windSpeed?.uom
+      );
+      const pressureHpa =
+        pressureRaw !== undefined
+          ? convertPressureToHpa(pressureRaw, gridData.properties.pressure?.uom)
+          : undefined;
 
       // Marine data (if available)
       const marine: MarineWeatherData = {
@@ -409,16 +475,26 @@ export class NWSWeatherService {
         marine.waveHeight !== undefined ||
         marine.waterTemperature !== undefined;
 
+      // NWS grid supplies probability of precipitation, not an amount.
+      // precipMm stays undefined rather than faking an amount from PoP.
+      const precipProbabilityPct =
+        precipProbability !== undefined
+          ? clampProbabilityPct(precipProbability)
+          : undefined;
+
+      const weatherFields: WeatherData = {
+        tempC,
+        windKph,
+        precipMm: undefined,
+        precipProbabilityPct,
+        cloudPct: cloudCover,
+        pressureHpa,
+      };
+
       // Assess safety
       const safety = this.assessSafety(
         alerts,
-        {
-          tempC: temp || 20,
-          windKph: (windSpeed || 10) * 3.6,
-          precipMm: (precipitation || 0) / 100,
-          cloudPct: cloudCover || 50,
-          pressureHpa: pressure ? pressure / 100 : undefined,
-        },
+        weatherFields,
         spcOutlook ? { spcOutlook } : undefined
       );
 
@@ -429,15 +505,12 @@ export class NWSWeatherService {
       );
 
       return {
-        tempC: temp || 20,
-        windKph: (windSpeed || 10) * 3.6, // m/s to km/h
-        precipMm: (precipitation || 0) / 100, // probability to mm (simplified)
-        cloudPct: cloudCover || 50,
-        pressureHpa: pressure ? pressure / 100 : undefined, // Pa to hPa
+        ...weatherFields,
         ...(hasMarineData && { marine }),
         safety,
         barometricTrend,
         source: "NWS",
+        sourceUpdatedIso: gridData.properties.updateTime,
         localOffice: localOffice || undefined,
       };
     } catch (error) {
@@ -543,8 +616,16 @@ export class NWSWeatherService {
       recommendations.push("Consider sheltered fishing spots");
     }
 
-    if (weather.precipMm > 10) {
+    if (weather.precipMm !== undefined && weather.precipMm > 10) {
       riskFactors.push("Heavy precipitation expected");
+      recommendations.push("Bring weather protection");
+    } else if (
+      weather.precipProbabilityPct !== undefined &&
+      weather.precipProbabilityPct >= 70
+    ) {
+      riskFactors.push(
+        `High chance of precipitation (${Math.round(weather.precipProbabilityPct)}%)`
+      );
       recommendations.push("Bring weather protection");
     }
 
@@ -647,13 +728,18 @@ export class NWSWeatherService {
   }
 
   private calculateBarometricTrend(
-    pressureValues: Array<{ validTime: string; value: number }> | undefined,
+    pressureValues: Array<{ validTime: string; value: number | null }> | undefined,
     targetDateTime: string
   ): "RISING" | "FALLING" | "STEADY" {
     if (!pressureValues || pressureValues.length < 2) return "STEADY";
 
     const targetTime = new Date(targetDateTime).getTime();
-    const recentValues = pressureValues
+    const recentValues = (
+      pressureValues.filter((v) => v.value !== null) as Array<{
+        validTime: string;
+        value: number;
+      }>
+    )
       .filter((v) => {
         const time = new Date(v.validTime).getTime();
         return Math.abs(time - targetTime) <= 6 * 60 * 60 * 1000; // 6 hours

--- a/src/lib/nwsWeather.ts
+++ b/src/lib/nwsWeather.ts
@@ -501,7 +501,8 @@ export class NWSWeatherService {
       // Calculate barometric trend (simplified)
       const barometricTrend = this.calculateBarometricTrend(
         gridData.properties.pressure?.values,
-        targetDateTime
+        targetDateTime,
+        gridData.properties.pressure?.uom
       );
 
       return {
@@ -729,7 +730,8 @@ export class NWSWeatherService {
 
   private calculateBarometricTrend(
     pressureValues: Array<{ validTime: string; value: number | null }> | undefined,
-    targetDateTime: string
+    targetDateTime: string,
+    uom?: string
   ): "RISING" | "FALLING" | "STEADY" {
     if (!pressureValues || pressureValues.length < 2) return "STEADY";
 
@@ -751,12 +753,17 @@ export class NWSWeatherService {
 
     if (recentValues.length < 2) return "STEADY";
 
-    const first = recentValues[0].value;
-    const last = recentValues[recentValues.length - 1].value;
+    // Normalize to hPa before diffing so the threshold below is unit-safe
+    // regardless of whether the feed reports Pa (the NWS default) or hPa.
+    const first = convertPressureToHpa(recentValues[0].value, uom);
+    const last = convertPressureToHpa(
+      recentValues[recentValues.length - 1].value,
+      uom
+    );
     const change = last - first;
 
-    if (change > 100) return "RISING"; // >1 hPa rise
-    if (change < -100) return "FALLING"; // >1 hPa fall
+    if (change > 1) return "RISING"; // >1 hPa rise
+    if (change < -1) return "FALLING"; // >1 hPa fall
     return "STEADY";
   }
 }

--- a/src/lib/openMeteo.ts
+++ b/src/lib/openMeteo.ts
@@ -13,7 +13,9 @@ interface OpenMeteoResponse {
 }
 
 /**
- * Fetch weather data from Open-Meteo for a specific day and location
+ * Fetch weather data from Open-Meteo for a specific day and location.
+ * Throws when the API fails or returns no usable data for the target day.
+ * Never returns synthetic/default weather.
  */
 export async function fetchWeather(day: DayInputs): Promise<WeatherData> {
   const baseUrl = "https://api.open-meteo.com/v1/forecast";
@@ -29,36 +31,33 @@ export async function fetchWeather(day: DayInputs): Promise<WeatherData> {
     longitude: day.lon.toString(),
     hourly:
       "temperature_2m,precipitation,cloud_cover,pressure_msl,windspeed_10m",
+    windspeed_unit: "kmh",
     timezone: "auto",
     forecast_days: Math.max(1, daysFromToday + 1).toString(),
   });
 
-  try {
-    const response = await fetch(`${baseUrl}?${params}`, {
-      signal: AbortSignal.timeout(20000), // 20s timeout
-    });
+  const response = await fetch(`${baseUrl}?${params}`, {
+    signal: AbortSignal.timeout(20000), // 20s timeout
+  });
 
-    if (!response.ok) {
-      throw new Error(`Open-Meteo API error: ${response.status}`);
-    }
-
-    const data: OpenMeteoResponse = await response.json();
-    return processWeatherData(data, day.date);
-  } catch (error) {
-    console.warn("Weather fetch failed, using defaults:", error);
-    return getDefaultWeatherData();
+  if (!response.ok) {
+    throw new Error(`Open-Meteo API error: ${response.status}`);
   }
+
+  const data: OpenMeteoResponse = await response.json();
+  return processWeatherData(data, day.date);
 }
 
 /**
- * Process Open-Meteo hourly data into averaged daylight-window metrics
+ * Process Open-Meteo hourly data into averaged daylight-window metrics.
+ * Throws when a required field has no usable values for the target day.
  */
 function processWeatherData(
   data: OpenMeteoResponse,
   targetDate: string
 ): WeatherData {
   const { hourly } = data;
-  const times = hourly.time || [];
+  const times = hourly?.time || [];
 
   // Filter for target date and daylight hours (6-18 local)
   const validIndices = times
@@ -70,48 +69,53 @@ function processWeatherData(
     .map(({ index }) => index);
 
   if (validIndices.length === 0) {
-    console.warn(`No daylight hours found for ${targetDate}, using defaults`);
-    return getDefaultWeatherData();
+    throw new Error(
+      `Open-Meteo returned no daylight-window data for ${targetDate}`
+    );
   }
 
   const avg = (
     field: keyof OpenMeteoResponse["hourly"],
-    defaultValue: number,
     scale = 1.0
-  ): number => {
+  ): number | undefined => {
     const arr = hourly[field] as number[] | undefined;
-    if (!arr) return defaultValue;
+    if (!arr) return undefined;
 
     const values = validIndices
       .map((i) => arr[i])
       .filter((val) => val != null && !isNaN(val));
 
-    if (values.length === 0) return defaultValue;
+    if (values.length === 0) return undefined;
 
     const sum = values.reduce((a, b) => a + b, 0);
     return (sum / values.length) * scale;
   };
 
-  return {
-    tempC: Math.round(avg("temperature_2m", 20.0) * 10) / 10,
-    windKph: Math.round(avg("windspeed_10m", 10.0, 3.6) * 10) / 10, // m/s -> km/h
-    precipMm: Math.round(avg("precipitation", 0.0) * 100) / 100,
-    cloudPct: Math.round(avg("cloud_cover", 50.0)),
-    pressureHpa: hourly.pressure_msl
-      ? Math.round(avg("pressure_msl", 1013.25) * 10) / 10
-      : undefined,
+  const requireField = (
+    field: keyof OpenMeteoResponse["hourly"],
+    scale = 1.0
+  ): number => {
+    const value = avg(field, scale);
+    if (value === undefined) {
+      throw new Error(
+        `Open-Meteo response missing required field "${field}" for ${targetDate}`
+      );
+    }
+    return value;
   };
-}
 
-/**
- * Fallback weather data for errors
- */
-function getDefaultWeatherData(): WeatherData {
+  const precipAvg = avg("precipitation");
+  const pressureAvg = avg("pressure_msl");
+
   return {
-    tempC: 20.0,
-    windKph: 10.0,
-    precipMm: 0.0,
-    cloudPct: 50,
-    pressureHpa: undefined,
+    tempC: Math.round(requireField("temperature_2m") * 10) / 10,
+    windKph: Math.round(requireField("windspeed_10m") * 10) / 10, // requested in km/h
+    precipMm:
+      precipAvg !== undefined ? Math.round(precipAvg * 100) / 100 : undefined,
+    cloudPct: Math.round(requireField("cloud_cover")),
+    pressureHpa:
+      pressureAvg !== undefined
+        ? Math.round(pressureAvg * 10) / 10
+        : undefined,
   };
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -428,7 +428,7 @@ export default function Home() {
           <h3 className="font-semibold mb-2 text-primary">Tactical Analysis</h3>
           <p className="text-sm text-secondary">
             Multi-factor algorithmic assessment providing precision strike
-            recommendations with confidence metrics
+            recommendations with data quality metrics
           </p>
         </div>
       </div>

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import type { ForecastScore, DayInputs } from "../types/forecast";
 import { fetchEnhancedWeather } from "../lib/enhancedWeather";
-import { forecastForDay } from "../lib/forecast";
+import { buildUnavailableForecast, forecastForDay } from "../lib/forecast";
 import {
   buildForecastCacheKey,
   getOfflineForecastCache,
@@ -92,11 +92,16 @@ export default function Results() {
           lon,
         };
 
-        // Fetch enhanced weather data
-        const weatherData = await fetchEnhancedWeather(dayInputs);
+        // Fetch enhanced weather data; UNAVAILABLE blocks the bite score
+        const weatherResult = await fetchEnhancedWeather(dayInputs);
+
+        if (weatherResult.status === "UNAVAILABLE") {
+          results.push(buildUnavailableForecast(dayInputs, weatherResult.reason));
+          continue;
+        }
 
         // Generate forecast (no almanac data for now)
-        const forecast = forecastForDay(dayInputs, weatherData);
+        const forecast = forecastForDay(dayInputs, weatherResult.weather);
 
         // Add astronomical and solunar data
         const timezone = getTimezoneFromCoords(lat, lon);
@@ -118,6 +123,25 @@ export default function Results() {
         forecast.solunar = solunar;
 
         results.push(forecast);
+      }
+
+      const allUnavailable = results.every(
+        (f) => f.forecastStatus === "WEATHER_UNAVAILABLE"
+      );
+
+      if (allUnavailable) {
+        // Prefer a cached real forecast (clearly marked cached/stale) over a
+        // page of blocked cards, and never overwrite the cache with them.
+        const cached = getOfflineForecastCache(cacheKey);
+        if (cached && cached.forecasts.length > 0) {
+          setForecasts(cached.forecasts);
+          setUsedCachedData(true);
+          setCachedLastUpdatedIso(cached.lastUpdatedIso);
+          setIsCachedDataStale(isCacheStale(cached.lastUpdatedIso));
+          return;
+        }
+        setForecasts(results);
+        return;
       }
 
       setForecasts(results);
@@ -191,19 +215,24 @@ export default function Results() {
     navigate("/");
   };
 
+  const availableForecasts = forecasts.filter(
+    (f) => f.forecastStatus !== "WEATHER_UNAVAILABLE"
+  );
+  const unavailableCount = forecasts.length - availableForecasts.length;
+
   const averageScore =
-    forecasts.length > 0
+    availableForecasts.length > 0
       ? Math.round(
-          (forecasts.reduce((sum, f) => sum + f.biteScore0100, 0) /
-            forecasts.length) *
+          (availableForecasts.reduce((sum, f) => sum + f.biteScore0100, 0) /
+            availableForecasts.length) *
             10
         ) / 10
       : 0;
 
-  const bestDay = forecasts.reduce(
+  const bestDay = availableForecasts.reduce(
     (best, current) =>
       current.biteScore0100 > best.biteScore0100 ? current : best,
-    forecasts[0]
+    availableForecasts[0]
   );
 
   if (isLoading) {
@@ -325,8 +354,26 @@ export default function Results() {
         </div>
       )}
 
+      {unavailableCount > 0 && (
+        <div
+          className="card p-4 mb-6 border-2 border-red-200 bg-red-50"
+          id="weather-unavailable-banner"
+        >
+          <p className="text-sm font-semibold text-red-700">
+            <Icon name="warning" className="mr-2" />
+            {unavailableCount === forecasts.length
+              ? "Weather unavailable. Bite scores paused."
+              : `Weather unavailable for ${unavailableCount} of ${forecasts.length} days. Those bite scores are paused.`}
+          </p>
+          <p className="text-xs text-red-700 mt-1">
+            Current weather could not be verified. Check official weather
+            before fishing.
+          </p>
+        </div>
+      )}
+
       {/* Summary */}
-      {forecasts.length > 0 && (
+      {availableForecasts.length > 0 && (
         <div className="grid gap-6 sm:grid-cols-2 mb-8" id="results-summary">
           <div className="card p-6" id="overall-outlook-card">
             <h3

--- a/src/types/forecast.ts
+++ b/src/types/forecast.ts
@@ -38,7 +38,10 @@ export interface AlmanacData {
   notes?: string;
 }
 
-export type ForecastAvailability = "OK" | "WEATHER_UNAVAILABLE";
+// Single-value union by design: "OK" has no distinct representation from
+// undefined, so it is never assigned. forecastStatus is either unset (OK)
+// or "WEATHER_UNAVAILABLE" -- there is exactly one way to express each state.
+export type ForecastAvailability = "WEATHER_UNAVAILABLE";
 
 export interface ForecastScore {
   date: string; // ISO date
@@ -51,10 +54,11 @@ export interface ForecastScore {
   solunar?: SolunarTimes;
   /**
    * "WEATHER_UNAVAILABLE" means no verified weather could be fetched; the bite
-   * score is not valid and must not be rendered as a normal forecast.
+   * score is not valid and must not be rendered as a normal forecast. Unset
+   * means OK -- there is no separate "OK" literal to avoid dual representation.
    */
   forecastStatus?: ForecastAvailability;
-  /** Human-readable reason when forecastStatus is not OK. */
+  /** Human-readable reason when forecastStatus is "WEATHER_UNAVAILABLE". */
   unavailableReason?: string;
 }
 

--- a/src/types/forecast.ts
+++ b/src/types/forecast.ts
@@ -21,7 +21,14 @@ export interface SolunarTimes {
 export interface WeatherData {
   tempC: number;
   windKph: number;
-  precipMm: number;
+  /**
+   * Measured/forecast precipitation amount in millimeters.
+   * Undefined when the source only provides a probability (e.g., NWS grid PoP).
+   * Never substitute probability values here.
+   */
+  precipMm?: number;
+  /** Probability of precipitation 0..100. Undefined when the source has no PoP. */
+  precipProbabilityPct?: number;
   cloudPct: number;
   pressureHpa?: number;
 }
@@ -30,6 +37,8 @@ export interface AlmanacData {
   rating01?: number; // 0..1, undefined if unavailable
   notes?: string;
 }
+
+export type ForecastAvailability = "OK" | "WEATHER_UNAVAILABLE";
 
 export interface ForecastScore {
   date: string; // ISO date
@@ -40,6 +49,13 @@ export interface ForecastScore {
   components: Record<string, number>;
   astronomical?: AstronomicalTimes;
   solunar?: SolunarTimes;
+  /**
+   * "WEATHER_UNAVAILABLE" means no verified weather could be fetched; the bite
+   * score is not valid and must not be rendered as a normal forecast.
+   */
+  forecastStatus?: ForecastAvailability;
+  /** Human-readable reason when forecastStatus is not OK. */
+  unavailableReason?: string;
 }
 
 export interface DayInputs {
@@ -99,6 +115,9 @@ export interface MarineWeatherData {
   windDirectionText?: string;
 }
 
+// Internal field names retain "confidence" for compatibility; all user-facing
+// copy must present these as "Data Quality" (source/freshness/completeness),
+// never as proven prediction accuracy.
 export type ForecastConfidenceLevel = "HIGH" | "MEDIUM" | "LOW";
 export type FreshnessLevel = "FRESH" | "AGING" | "STALE" | "UNKNOWN";
 export type MarineDataStatus = "AVAILABLE" | "UNAVAILABLE" | "NOT_APPLICABLE";
@@ -110,12 +129,15 @@ export interface ForecastReliability {
   weatherFreshness: FreshnessLevel;
   marineFreshness: FreshnessLevel;
   marineStatus: MarineDataStatus;
+  /** When the app generated this forecast (fetch/build time). */
+  forecastGeneratedIso?: string;
+  /** When the weather SOURCE last updated its data. Unset when the source provides no timestamp. */
   weatherLastUpdatedIso?: string;
   marineLastUpdatedIso?: string;
 }
 
 export interface SafetyAssessment {
-  rating: "EXCELLENT" | "GOOD" | "FAIR" | "POOR" | "DANGEROUS";
+  rating: "EXCELLENT" | "GOOD" | "FAIR" | "POOR" | "DANGEROUS" | "UNKNOWN";
   activeAlerts: NWSAlert[];
   recommendations: string[];
   riskFactors: string[];
@@ -126,7 +148,9 @@ export interface EnhancedWeatherData extends WeatherData {
   marine?: MarineWeatherData;
   safety: SafetyAssessment;
   barometricTrend: "RISING" | "FALLING" | "STEADY";
-  source: "NWS" | "OPEN_METEO" | "FUSED";
+  source: "NWS" | "OPEN_METEO" | "FUSED" | "UNAVAILABLE";
+  /** Timestamp the SOURCE reports for its own data (e.g., NWS grid updateTime). */
+  sourceUpdatedIso?: string;
   reliability?: ForecastReliability;
   localOffice?: LocalWeatherOfficeInfo;
 }

--- a/tests/weatherValidation.test.ts
+++ b/tests/weatherValidation.test.ts
@@ -174,7 +174,8 @@ describe("weather validation: source selection", () => {
 
   it("classifies US bounds correctly", () => {
     expect(isUSLocation(DENVER.lat, DENVER.lon)).toBe(true);
-    expect(isUSLocation(21.3045, -157.8557)).toBe(false); // Honolulu is below the 24N rough bound
+    expect(isUSLocation(21.3045, -157.8557)).toBe(true); // Honolulu, HI
+    expect(isUSLocation(49.2827, -123.1207)).toBe(false); // Vancouver, BC
     expect(isUSLocation(PARIS.lat, PARIS.lon)).toBe(false);
     expect(isUSLocation(19.4326, -99.1332)).toBe(false); // Mexico City
   });

--- a/tests/weatherValidation.test.ts
+++ b/tests/weatherValidation.test.ts
@@ -1,0 +1,405 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EnhancedWeatherData, NWSAlert } from "../src/types/forecast";
+
+vi.mock("../src/lib/nwsWeather", async () => {
+  const actual = await vi.importActual<
+    typeof import("../src/lib/nwsWeather")
+  >("../src/lib/nwsWeather");
+  return {
+    ...actual,
+    nwsWeatherService: {
+      fetchEnhancedWeather: vi.fn(),
+    },
+  };
+});
+
+vi.mock("../src/lib/openMeteo", () => ({
+  fetchWeather: vi.fn(),
+}));
+
+vi.mock("../src/lib/noaaMarine", () => ({
+  fetchNoaaMarineConditionsWithMeta: vi.fn().mockResolvedValue({
+    marine: null,
+    reason: "API_ERROR",
+  }),
+}));
+
+import {
+  adjustSafetyWithMarine,
+  fetchEnhancedWeather,
+  isUSLocation,
+} from "../src/lib/enhancedWeather";
+import { nwsWeatherService } from "../src/lib/nwsWeather";
+import { fetchWeather as fetchOpenMeteoWeather } from "../src/lib/openMeteo";
+import {
+  NWSWeatherService,
+  clampProbabilityPct,
+  convertPressureToHpa,
+  convertTemperatureToC,
+  convertWindToKph,
+} from "../src/lib/nwsWeather";
+import {
+  buildUnavailableForecast,
+  scorePrecipitation,
+  scoreWeather,
+} from "../src/lib/forecast";
+import { buildForecastReliability } from "../src/lib/forecastReliability";
+
+const mockedNwsFetch = vi.mocked(nwsWeatherService.fetchEnhancedWeather);
+const mockedOpenMeteoFetch = vi.mocked(fetchOpenMeteoWeather);
+
+const DENVER = { lat: 39.7392, lon: -104.9903 }; // US, not marine eligible
+const PARIS = { lat: 48.8566, lon: 2.3522 }; // non-US
+
+function makeNwsWeather(): EnhancedWeatherData {
+  return {
+    tempC: 18,
+    windKph: 12,
+    precipMm: undefined,
+    precipProbabilityPct: 20,
+    cloudPct: 30,
+    pressureHpa: 1015,
+    safety: {
+      rating: "GOOD",
+      activeAlerts: [],
+      recommendations: [],
+      riskFactors: [],
+    },
+    barometricTrend: "STEADY",
+    source: "NWS",
+    sourceUpdatedIso: new Date().toISOString(),
+  };
+}
+
+function makeOpenMeteoWeather() {
+  return {
+    tempC: 17,
+    windKph: 9,
+    precipMm: 0.4,
+    cloudPct: 45,
+    pressureHpa: 1012,
+  };
+}
+
+function makeBaseSafety() {
+  return {
+    rating: "GOOD" as const,
+    activeAlerts: [],
+    recommendations: [],
+    riskFactors: [],
+  };
+}
+
+beforeEach(() => {
+  mockedNwsFetch.mockReset();
+  mockedOpenMeteoFetch.mockReset();
+});
+
+describe("weather validation: source selection", () => {
+  it("prefers NWS for US coordinates", async () => {
+    mockedNwsFetch.mockResolvedValue(makeNwsWeather());
+
+    const result = await fetchEnhancedWeather({
+      date: "2026-07-03",
+      ...DENVER,
+    });
+
+    expect(result.status).toBe("OK");
+    if (result.status === "UNAVAILABLE") throw new Error("unexpected");
+    expect(result.weather.source).toBe("NWS");
+    expect(mockedNwsFetch).toHaveBeenCalledTimes(1);
+    expect(mockedOpenMeteoFetch).not.toHaveBeenCalled();
+  });
+
+  it("uses Open-Meteo as primary (not fallback) for non-US coordinates", async () => {
+    mockedOpenMeteoFetch.mockResolvedValue(makeOpenMeteoWeather());
+
+    const result = await fetchEnhancedWeather({
+      date: "2026-07-03",
+      ...PARIS,
+    });
+
+    expect(result.status).toBe("OK");
+    if (result.status === "UNAVAILABLE") throw new Error("unexpected");
+    expect(result.weather.source).toBe("OPEN_METEO");
+    expect(mockedNwsFetch).not.toHaveBeenCalled();
+    expect(
+      result.weather.reliability?.reasons.join(" ")
+    ).not.toContain("fallback");
+  });
+
+  it("falls back to Open-Meteo when NWS fails and marks the fallback", async () => {
+    mockedNwsFetch.mockRejectedValue(new Error("NWS API error: 503"));
+    mockedOpenMeteoFetch.mockResolvedValue(makeOpenMeteoWeather());
+
+    const result = await fetchEnhancedWeather({
+      date: "2026-07-03",
+      ...DENVER,
+    });
+
+    expect(result.status).toBe("FALLBACK");
+    if (result.status === "UNAVAILABLE") throw new Error("unexpected");
+    expect(result.weather.source).toBe("OPEN_METEO");
+    expect(result.weather.reliability?.reasons.join(" ")).toContain(
+      "fallback"
+    );
+  });
+
+  it("returns UNAVAILABLE when every weather source fails", async () => {
+    mockedNwsFetch.mockRejectedValue(new Error("NWS API error: 503"));
+    mockedOpenMeteoFetch.mockRejectedValue(
+      new Error("Open-Meteo API error: 500")
+    );
+
+    const result = await fetchEnhancedWeather({
+      date: "2026-07-03",
+      ...DENVER,
+    });
+
+    expect(result.status).toBe("UNAVAILABLE");
+  });
+
+  it("blocks the bite score when weather is unavailable", () => {
+    const forecast = buildUnavailableForecast(
+      { date: "2026-07-03", ...DENVER },
+      "Current weather could not be verified from any source"
+    );
+
+    expect(forecast.forecastStatus).toBe("WEATHER_UNAVAILABLE");
+    expect(forecast.biteScore0100).toBe(0);
+    expect(forecast.weather.safety.rating).toBe("UNKNOWN");
+    expect(forecast.weather.source).toBe("UNAVAILABLE");
+    expect(Number.isNaN(forecast.weather.tempC)).toBe(true);
+  });
+
+  it("classifies US bounds correctly", () => {
+    expect(isUSLocation(DENVER.lat, DENVER.lon)).toBe(true);
+    expect(isUSLocation(21.3045, -157.8557)).toBe(false); // Honolulu is below the 24N rough bound
+    expect(isUSLocation(PARIS.lat, PARIS.lon)).toBe(false);
+    expect(isUSLocation(19.4326, -99.1332)).toBe(false); // Mexico City
+  });
+});
+
+describe("weather validation: unit correctness", () => {
+  it("converts wind speeds by unit of measure", () => {
+    expect(convertWindToKph(10, "wmoUnit:km_h-1")).toBeCloseTo(10);
+    expect(convertWindToKph(10, undefined)).toBeCloseTo(10); // NWS default km/h
+    expect(convertWindToKph(10, "wmoUnit:m_s-1")).toBeCloseTo(36);
+    expect(convertWindToKph(10, "wmoUnit:kn")).toBeCloseTo(18.52);
+    expect(convertWindToKph(10, "wmoUnit:mi_h-1")).toBeCloseTo(16.09344);
+  });
+
+  it("converts pressure by unit of measure", () => {
+    expect(convertPressureToHpa(101325, "wmoUnit:Pa")).toBeCloseTo(1013.25);
+    expect(convertPressureToHpa(101325, undefined)).toBeCloseTo(1013.25);
+    expect(convertPressureToHpa(1013.25, "wmoUnit:hPa")).toBeCloseTo(1013.25);
+  });
+
+  it("converts temperature by unit of measure", () => {
+    expect(convertTemperatureToC(20, "wmoUnit:degC")).toBeCloseTo(20);
+    expect(convertTemperatureToC(68, "wmoUnit:degF")).toBeCloseTo(20);
+  });
+
+  it("clamps precipitation probability to 0..100", () => {
+    expect(clampProbabilityPct(-5)).toBe(0);
+    expect(clampProbabilityPct(50)).toBe(50);
+    expect(clampProbabilityPct(140)).toBe(100);
+  });
+
+  it("scores precipitation probability on its own scale, never as an amount", () => {
+    // Amount takes precedence when present
+    expect(scorePrecipitation(12, undefined)).toBe(0.1);
+    expect(scorePrecipitation(0, undefined)).toBe(0.8);
+
+    // Probability-only scoring
+    expect(scorePrecipitation(undefined, 10)).toBe(0.8);
+    expect(scorePrecipitation(undefined, 40)).toBe(0.6);
+    expect(scorePrecipitation(undefined, 70)).toBe(0.4);
+    expect(scorePrecipitation(undefined, 95)).toBe(0.2);
+
+    // A 90% probability must not be scored like 0.9mm of light rain
+    expect(scorePrecipitation(undefined, 90)).not.toBe(
+      scorePrecipitation(0.9, undefined)
+    );
+
+    // Neither available: neutral
+    expect(scorePrecipitation(undefined, undefined)).toBe(0.6);
+  });
+
+  it("keeps weather score within bounds at cloud cover extremes", () => {
+    for (const cloudPct of [0, 50, 100]) {
+      const score = scoreWeather({
+        tempC: 18,
+        windKph: 10,
+        precipMm: 0,
+        cloudPct,
+      });
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe("weather validation: safety overrides", () => {
+  const service = new NWSWeatherService();
+  const baseAlert: NWSAlert = {
+    id: "a1",
+    headline: "Test",
+    severity: "Minor",
+    urgency: "Future",
+    certainty: "Possible",
+    event: "Test Event",
+    description: "",
+    areas: [],
+  };
+  const calmWeather = {
+    tempC: 20,
+    windKph: 10,
+    precipMm: 0,
+    cloudPct: 50,
+  };
+
+  it("forces DANGEROUS for severe and extreme alerts", () => {
+    for (const severity of ["Severe", "Extreme"] as const) {
+      const result = service.assessSafety(
+        [{ ...baseAlert, severity }],
+        calmWeather
+      );
+      expect(result.rating).toBe("DANGEROUS");
+    }
+  });
+
+  it("degrades safety for moderate alerts", () => {
+    const result = service.assessSafety(
+      [{ ...baseAlert, severity: "Moderate" }],
+      calmWeather
+    );
+    expect(result.rating).toBe("FAIR");
+  });
+
+  it("flags high precipitation probability as a risk factor", () => {
+    const result = service.assessSafety([], {
+      ...calmWeather,
+      precipMm: undefined,
+      precipProbabilityPct: 85,
+    });
+    expect(result.riskFactors.join(" ")).toContain("chance of precipitation");
+  });
+
+  it("degrades safety for marine high wind", () => {
+    const adjusted = adjustSafetyWithMarine(
+      makeBaseSafety(),
+      { windSpeedKph: 60 },
+      "2026-07-03"
+    );
+    expect(adjusted.rating).toBe("DANGEROUS");
+  });
+
+  it("degrades safety for marine high waves", () => {
+    const adjusted = adjustSafetyWithMarine(
+      makeBaseSafety(),
+      { waveHeight: 3.2 },
+      "2026-07-03"
+    );
+    expect(adjusted.rating).toBe("DANGEROUS");
+
+    const moderate = adjustSafetyWithMarine(
+      makeBaseSafety(),
+      { waveHeight: 2.6 },
+      "2026-07-03"
+    );
+    expect(moderate.rating).toBe("POOR");
+  });
+
+  it("zeroes the bite-relevant weather score under DANGEROUS safety regardless of source", () => {
+    const score = scoreWeather({
+      tempC: 18,
+      windKph: 10,
+      precipMm: 0,
+      cloudPct: 30,
+      safety: {
+        rating: "DANGEROUS",
+        activeAlerts: [],
+        recommendations: [],
+        riskFactors: [],
+      },
+      barometricTrend: "STEADY",
+      source: "OPEN_METEO",
+    });
+    expect(score).toBe(0);
+  });
+});
+
+describe("weather validation: data quality (reliability)", () => {
+  function makeWeather(): EnhancedWeatherData {
+    return {
+      tempC: 18,
+      windKph: 10,
+      precipMm: 0,
+      cloudPct: 30,
+      safety: makeBaseSafety(),
+      barometricTrend: "STEADY",
+      source: "NWS",
+    };
+  }
+
+  it("does not mark freshness FRESH when the source provides no timestamp", () => {
+    const reliability = buildForecastReliability(makeWeather(), {
+      isMarineEligible: false,
+      nowIso: "2026-07-03T12:00:00Z",
+      forecastGeneratedIso: "2026-07-03T12:00:00Z",
+      // no weatherLastUpdatedIso: app fetch time must not count as freshness
+    });
+
+    expect(reliability.weatherFreshness).toBe("UNKNOWN");
+    expect(reliability.confidenceScore).toBeLessThan(100);
+  });
+
+  it("reduces data quality for a fallback source", () => {
+    const primary = buildForecastReliability(makeWeather(), {
+      isMarineEligible: false,
+      isFallbackSource: false,
+      nowIso: "2026-07-03T12:00:00Z",
+      weatherLastUpdatedIso: "2026-07-03T11:00:00Z",
+    });
+    const fallback = buildForecastReliability(
+      { ...makeWeather(), source: "OPEN_METEO" },
+      {
+        isMarineEligible: false,
+        isFallbackSource: true,
+        nowIso: "2026-07-03T12:00:00Z",
+        weatherLastUpdatedIso: "2026-07-03T11:00:00Z",
+      }
+    );
+
+    expect(fallback.confidenceScore).toBeLessThan(primary.confidenceScore);
+  });
+
+  it("reduces data quality when a marine-eligible location has no marine observations", () => {
+    const withoutMarine = buildForecastReliability(makeWeather(), {
+      isMarineEligible: true,
+      nowIso: "2026-07-03T12:00:00Z",
+      weatherLastUpdatedIso: "2026-07-03T11:00:00Z",
+    });
+    const notEligible = buildForecastReliability(makeWeather(), {
+      isMarineEligible: false,
+      nowIso: "2026-07-03T12:00:00Z",
+      weatherLastUpdatedIso: "2026-07-03T11:00:00Z",
+    });
+
+    expect(withoutMarine.marineStatus).toBe("UNAVAILABLE");
+    expect(withoutMarine.confidenceScore).toBeLessThan(
+      notEligible.confidenceScore
+    );
+  });
+
+  it("never yields a normal-looking score for a blocked forecast", () => {
+    const forecast = buildUnavailableForecast(
+      { date: "2026-07-03", ...DENVER },
+      "test"
+    );
+    expect(forecast.forecastStatus).toBe("WEATHER_UNAVAILABLE");
+    expect(forecast.components).toEqual({});
+    expect(forecast.biteScore0100).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR overhauls weather data trust and accuracy: it removes all synthetic/default weather fallbacks (20°C, 10 km/h wind, 0 precip, 1013.25 hPa) so a bite score can never be calculated from fabricated data — when both NWS and Open-Meteo fail, the forecast is blocked and the UI clearly shows "Forecast unavailable / Check official weather before fishing" instead of a normal-looking score. It also fixes several correctness bugs: NWS wind speed was being multiplied by 3.6 as if it were m/s when the API already returns km/h (inflating wind ~3.6x), NWS precipitation probability (a percentage) was being displayed and scored as a rain amount in millimeters, and forecast "freshness" was derived from the app's own fetch time rather than the source's actual update timestamp (so data was marked fresh even when the source hadn't updated). Precipitation probability and amount are now tracked and displayed as distinct fields, source timestamps are used where available (falling back to an explicit "Unknown" rather than claiming freshness), and the previously-named "Confidence" indicator is relabeled "Data Quality" in the UI to avoid implying proven predictive accuracy. A new deterministic validation harness (`npm run validate:weather`) and test suite cover source selection/fallback/failure handling, unit conversions, precipitation semantics, and safety overrides across 25 locations.
